### PR TITLE
kubernetes: make `kubectl run -it` functional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Moby (`dockerd`):
 * Running rootless `dockerd` in rootless/rootful `dockerd` is also possible, but not fully tested.
 
 Kubernetes:
-* `kubectl run -it` not working? (`kubectl run` works)
+* Pods crash intermittently
 
 ## Install from binary
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,6 @@ tasks:
         --etcd-servers http://127.0.0.1:2379 \
         --admission-control=AlwaysAdmit \
         --authorization-mode=AlwaysAllow \
-        --kubelet-https=false \
         --anonymous-auth=true
   kube-controller-manager:
     cmds:


### PR DESCRIPTION
`--kubelet-https=false` was actually unneeded and did not work

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>