### PR TITLE
usernetes: add support for CRI-O

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,18 @@ $ task -d build
 
 ## Quick start
 
-### Start the daemons
+### Start the daemons using Docker
 
 ```console
 $ ./run.sh
 ```
+
+### Start the daemons using CRI-O
+
+```console
+$ ./run.sh default-crio
+```
+### Start dockerd only (No Kubernetes)
 
 If you don't need Kubernetes:
 ```console

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-# Usernetes: Docker & Kubernetes without the root privileges
+# Usernetes: (CRIO|Docker) & Kubernetes without the root privileges
 #
 # You need to use `run.sh` for executing these tasks.
 # Please refer to `README.md` for the usage.
@@ -7,6 +7,20 @@ version: '2'
 output: prefixed
 
 tasks:
+  crio:
+    env:
+      _CRIO_ROOTLESS: 1
+    cmds:
+      - test $_USERNETES_CHILD
+      - mkdir -p $HOME/.local/share/containers
+      - |
+        crio \
+        --conmon $(pwd)/bin/crio/conmon \
+        --runroot $XDG_RUNTIME_DIR/crio \
+        --cni-config-dir $(pwd)/bin/crio/cni/conf \
+        --cni-plugin-dir $(pwd)/bin/crio/cni/plugins \
+        --root $HOME/.local/share/containers/storage --cgroup-manager=cgroupfs \
+        --storage-driver vfs --runtime $(pwd)/bin/crio/runc
   dockerd:
     cmds:
       - test $_USERNETES_CHILD
@@ -47,5 +61,23 @@ tasks:
         --authorization-mode=AlwaysAllow \
         --fail-swap-on=false \
         --feature-gates DevicePlugins=false
+  kubelet-crio:
+    cmds:
+      - test $_USERNETES_CHILD
+      - |
+        hyperkube kubelet \
+        --container-runtime remote \
+        --container-runtime-endpoint unix:///run/crio/crio.sock \
+        --cert-dir $HOME/.config/usernetes/pki \
+        --root-dir $HOME/.local/share/usernetes/kubelet \
+        --log-dir $HOME/.local/share/usernetes/kubelet-log \
+        --volume-plugin-dir $HOME/.local/share/usernetes/kubelet-plugins-exec \
+        --kubeconfig localhost.kubeconfig \
+        --anonymous-auth=true \
+        --authorization-mode=AlwaysAllow \
+        --fail-swap-on=false \
+        --feature-gates DevicePlugins=false
   default:
     deps: [dockerd,etcd,kube-apiserver,kube-controller-manager,kube-scheduler,kubelet]
+  default-crio:
+    deps: [crio,etcd,kube-apiserver,kube-controller-manager,kube-scheduler,kubelet-crio]

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -9,6 +9,8 @@ vars:
   MOBY_COMMIT: ca359685a7c63419615dfb6174c51755fcc6acbc
   KUBERNETES_REPO: https://github.com/AkihiroSuda/kubernetes.git
   KUBERNETES_COMMIT: 831875979e75426c7385cd1fff2355ce51b5a0f7
+  CRIO_COMMIT: 2accad9fab352c445bb4c414d9d3c8cdf351c524
+  RUNC_COMMIT: 20aff4f0488c6d4b8df4d85b4f63f1f704c11abd
 # Kube's build script requires KUBE_GIT_VERSION to be set to a semver string
   KUBE_GIT_VERSION: v1.12-usernetes
   ETCD_RELEASE: v3.3.9
@@ -18,6 +20,14 @@ tasks:
   clean:
     cmds:
       - rm -rf ../bin ../_artifact
+  build-crio:
+    cmds:
+      - |
+        docker build -t usernetes-build-crio -f crio.Dockerfile \
+        --build-arg CRIO_COMMIT={{.CRIO_COMMIT}} \
+        --build-arg RUNC_COMMIT={{.RUNC_COMMIT}} .
+      - mkdir -p ../bin
+      - docker run --rm usernetes-build-crio sh -c 'cd /; tar chf - crio' | tar Cxvf ../bin -
   build-rootlesskit:
     cmds:
       - |
@@ -77,6 +87,6 @@ tasks:
       - mkdir -p ../_artifact
       - ( cd .. ; tar --transform 's@^\.@usernetes@' --exclude-vcs --exclude=./_artifact -cjvf ./_artifact/usernetes-x86_64.tbz . )
   default:
-    deps: [build-rootlesskit,build-slirp4netns,build-moby,build-kubernetes,build-etcd,build-go-task]
+    deps: [build-rootlesskit,build-slirp4netns,build-moby,build-crio,build-kubernetes,build-etcd,build-go-task]
     cmds:
       - task: build-artifact

--- a/build/crio.Dockerfile
+++ b/build/crio.Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:alpine
+RUN apk add --no-cache git build-base gpgme-dev linux-headers glib-dev glib-static
+ARG CRIO_COMMIT
+RUN echo CRIO_COMMIT=${CRIO_COMMIT} RUNC_COMMIT=${RUNC_COMMIT}
+
+RUN git clone https://github.com/kubernetes-incubator/cri-o.git /go/src/github.com/kubernetes-incubator/cri-o && \
+  cd /go/src/github.com/kubernetes-incubator/cri-o && git checkout ${CRIO_COMMIT} && \
+  make CFLAGS="-static" BUILDTAGS="exclude_graphdriver_btrfs exclude_graphdriver_devicemapper" binaries && \
+  mkdir -p /crio/cni/plugins/ /crio/cni/conf && \
+  cp bin/conmon bin/crio /crio && \
+  cp contrib/cni/* /crio/cni/conf && \
+  git clone https://github.com/containernetworking/plugins /go/src/github.com/containernetworking/plugins && \
+  cd /go/src/github.com/containernetworking/plugins && \
+  sh ./build.sh -ldflags "-extldflags -static" && \
+  cp bin/* /crio/cni/plugins && \
+  git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc && \
+  cd /go/src/github.com/opencontainers/runc && git checkout ${RUNC_COMMIT} && \
+  make BUILDTAGS="" SHELL=/bin/sh static && \
+  cp runc /crio/runc


### PR DESCRIPTION
Depends on: https://github.com/kubernetes-incubator/cri-o/pull/1729

I will drop the WIP tag once it lands into CRIO upstream and can fix the commit used here.

Closes: https://github.com/rootless-containers/usernetes/issues/11

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>