### PR TITLE
[k8s] Prevent pods from being killed immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Usernetes aims to provide a binary distribution of Moby (aka Docker) and Kuberne
 ## Status
 
 * Moby (`dockerd`): Almost usable (except Swarm-mode)
-* Kubernetes: Early POC with a single node. Don't use yet!
+* Kubernetes: Early POC with a single node
 
 We also plan to support containerd and CRI-O as CRI runtimes.
 
@@ -38,7 +38,7 @@ Moby (`dockerd`):
 * Running rootless `dockerd` in rootless/rootful `dockerd` is also possible, but not fully tested.
 
 Kubernetes:
-* Pods crash intermittently
+* (Almost untested)
 
 ## Install from binary
 

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -6,13 +6,13 @@ vars:
   ROOTLESSKIT_COMMIT: 28cb87941b51b7e542492d763218989a5260c07d
   SLIRP4NETNS_COMMIT: 0037042e2facc8818d0a254e320a739648283f2e
   MOBY_REPO: https://github.com/AkihiroSuda/docker.git
-  MOBY_COMMIT: 82cd9a375b395d825e3ca1784589b3a06b99d0c4
+  MOBY_COMMIT: ca359685a7c63419615dfb6174c51755fcc6acbc
   KUBERNETES_REPO: https://github.com/AkihiroSuda/kubernetes.git
-  KUBERNETES_COMMIT: 947fbddfeb039a8cbe21bd8b5b9917bb209d06c7
+  KUBERNETES_COMMIT: 831875979e75426c7385cd1fff2355ce51b5a0f7
 # Kube's build script requires KUBE_GIT_VERSION to be set to a semver string
   KUBE_GIT_VERSION: v1.12-usernetes
   ETCD_RELEASE: v3.3.9
-  GOTASK_RELEASE: v2.0.3
+  GOTASK_RELEASE: v2.1.0
 
 tasks:
   clean:


### PR DESCRIPTION
`kubelet.go:1526:syncPod()` is updated to prevent pods from being killed
immediately due to `!pcm.Exists()`.

https://github.com/AkihiroSuda/kubernetes/commit/831875979e75426c7385cd1fff2355ce51b5a0f7#diff-bf28da68f62a8df6e99e447c4351122dR1526

Before we propose our change to the Kubernetes upstream, probably we need to
implement rootless PCM in the proper way.

Fix #10

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>