### PR TITLE
crio: configure --registry

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,8 +13,19 @@ tasks:
     cmds:
       - test $_USERNETES_CHILD
       - mkdir -p $HOME/.local/share/containers
+      - mkdir -p $HOME/.config/crio
+# It looks like both crio.conf["registries"] and --registry CLI flags are needed
+# https://trello.com/c/kmdF350I/521-8-registry-patch-in-cri-o
+      - cmd: |
+          [ ! -f $HOME/.config/crio/crio.conf ] && \
+          cat  > $HOME/.config/crio/crio.conf << EOF
+          registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
+          EOF
+        ignore_error: true
       - |
         $(pwd)/bin/crio/crio \
+        --config $HOME/.config/crio/crio.conf \
+        --registry registry.access.redhat.com --registry registry.fedoraproject.org --registry docker.io \
         --conmon $(pwd)/bin/crio/conmon \
         --runroot $XDG_RUNTIME_DIR/crio \
         --cni-config-dir $(pwd)/bin/crio/cni/conf \

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -11,6 +11,6 @@ if [ -z $HOME ]; then
 fi
 
 # use RootlessKit for removing files owned by sub-IDs.
-./bin/rootlesskit rm -rf $XDG_RUNTIME_DIR/usernetes $HOME/.local/share/usernetes $HOME/.local/share/docker
+./bin/rootlesskit rm -rf $XDG_RUNTIME_DIR/usernetes $HOME/.local/share/usernetes $HOME/.local/share/docker $HOME/.local/share/containers
 
-echo "You may also want to remove manually: ~/.config/{docker,usernetes} ~/.docker ~/.kube"
+echo "You may also want to remove manually: ~/.config/{docker,crio,usernetes} ~/.docker ~/.kube"


### PR DESCRIPTION
I'm not sure this fix is correct, but without this fix, I could not run `kubectl run -it --rm --image alpine foo`.

@giuseppe 

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
