### PR TITLE
decouple runc and cni from crio ; decouple containerd from moby

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,20 +31,20 @@ tasks:
           EOF
         ignore_error: true
       - |
-        $(pwd)/bin/crio/crio \
+        $(pwd)/bin/crio \
         --signature-policy $HOME/.config/containers/policy.json \
         --config $HOME/.config/crio/crio.conf \
         --registry registry.access.redhat.com --registry registry.fedoraproject.org --registry docker.io \
-        --conmon $(pwd)/bin/crio/conmon \
+        --conmon $(pwd)/bin/conmon \
         --runroot $XDG_RUNTIME_DIR/crio \
-        --cni-config-dir $(pwd)/bin/crio/cni/conf \
-        --cni-plugin-dir $(pwd)/bin/crio/cni/plugins \
+        --cni-config-dir $(pwd)/config/crio/cni \
+        --cni-plugin-dir $(pwd)/bin/cni \
         --root $HOME/.local/share/containers/storage --cgroup-manager=cgroupfs \
-        --storage-driver vfs --runtime $(pwd)/bin/crio/runc
+        --storage-driver vfs --runtime $(pwd)/bin/runc
   dockerd:
     cmds:
       - test $_USERNETES_CHILD
-      - PATH=$(pwd)/bin/moby:$PATH $(pwd)/bin/moby/dockerd --experimental
+      - dockerd --experimental
   etcd:
     cmds:
       - test $_USERNETES_CHILD

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -52,21 +52,11 @@ tasks:
       - docker run --rm usernetes-build-slirp4netns sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
   build-moby:
     cmds:
-      - docker rm -f usernetes-build-moby 2> /dev/null || true
-      - docker volume create usernetes-build-moby-cache
       - |
         docker build -t usernetes-build-moby -f moby.Dockerfile \
         --build-arg MOBY_COMMIT={{.MOBY_COMMIT}} .
-      - |
-        docker run --name usernetes-build-moby \
-        -d  --privileged \
-        -v usernetes-build-moby-cache:/var/lib/docker \
-        usernetes-build-moby dockerd --experimental
-      - docker exec -e DOCKER_BUILDKIT=1 usernetes-build-moby make binary
       - mkdir -p ../bin
-# `docker exec -w` is not available in Docker 17.09
-      - docker exec usernetes-build-moby sh -c 'cd /moby/bundles/binary-daemon; tar chf - dockerd docker-init docker-proxy' | tar Cxvf ../bin -
-      - docker rm -f usernetes-build-moby
+      - docker run --rm usernetes-build-moby sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
   build-docker-cli:
     cmds:
       - docker rm -f usernetes-build-docker-cli 2> /dev/null || true

--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -13,9 +13,11 @@ vars:
   KUBERNETES_COMMIT: 839c4ec7c3fb117ae7753343b0523814a36ab7f9
 # 10/30/2018
   CRIO_COMMIT: f58419d6cf462070a0c3727ad2dc554ef151e832
-# 11/06/2018; RUNC_COMMIT is only for CRIO at the moment
+# 11/06/2018
+  CONTAINERD_COMMIT: 8dcabd6125f8586fb2e13586b72874bc084e1b32
+# 11/06/2018
   RUNC_COMMIT: b1068fb9258d2cc5aa59505fbb703d914120013d
-# 10/18/2018; CNI_PLUGINS_COMMIT is only for CRIO at the moment
+# 10/18/2018
   CNI_PLUGINS_COMMIT: b93d284d18dfc8ba93265fa0aa859c7e92df411b
 # Kube's build script requires KUBE_GIT_VERSION to be set to a semver string
   KUBE_GIT_VERSION: v1.13-usernetes
@@ -31,25 +33,23 @@ tasks:
     cmds:
       - |
         docker build -t usernetes-build-crio -f crio.Dockerfile \
-        --build-arg CRIO_COMMIT={{.CRIO_COMMIT}} \
-        --build-arg CNI_PLUGINS_COMMIT={{.CNI_PLUGINS_COMMIT}} \
-        --build-arg RUNC_COMMIT={{.RUNC_COMMIT}} .
+        --build-arg CRIO_COMMIT={{.CRIO_COMMIT}} .
       - mkdir -p ../bin
-      - docker run --rm usernetes-build-crio sh -c 'cd /; tar chf - crio' | tar Cxvf ../bin -
+      - docker run --rm usernetes-build-crio sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
   build-rootlesskit:
     cmds:
       - |
         docker build -t usernetes-build-rootlesskit -f rootlesskit.Dockerfile \
         --build-arg ROOTLESSKIT_COMMIT={{.ROOTLESSKIT_COMMIT}} .
       - mkdir -p ../bin
-      - docker run --rm usernetes-build-rootlesskit sh -c 'cd /; tar chf - rootlesskit' | tar Cxvf ../bin -
+      - docker run --rm usernetes-build-rootlesskit sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
   build-slirp4netns:
     cmds:
       - |
         docker build -t usernetes-build-slirp4netns -f slirp4netns.Dockerfile \
         --build-arg SLIRP4NETNS_COMMIT={{.SLIRP4NETNS_COMMIT}} .
       - mkdir -p ../bin
-      - docker run --rm usernetes-build-slirp4netns sh -c 'cd /slirp4netns; tar chf - slirp4netns' | tar Cxvf ../bin -
+      - docker run --rm usernetes-build-slirp4netns sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
   build-moby:
     cmds:
       - docker rm -f usernetes-build-moby 2> /dev/null || true
@@ -63,9 +63,9 @@ tasks:
         -v usernetes-build-moby-cache:/var/lib/docker \
         usernetes-build-moby dockerd --experimental
       - docker exec -e DOCKER_BUILDKIT=1 usernetes-build-moby make binary
-      - mkdir -p ../bin/moby
+      - mkdir -p ../bin
 # `docker exec -w` is not available in Docker 17.09
-      - docker exec usernetes-build-moby sh -c 'cd /moby/bundles/binary-daemon; tar chf - dockerd containerd ctr containerd-shim runc docker-init docker-proxy' | tar Cxvf ../bin/moby -
+      - docker exec usernetes-build-moby sh -c 'cd /moby/bundles/binary-daemon; tar chf - dockerd docker-init docker-proxy' | tar Cxvf ../bin -
       - docker rm -f usernetes-build-moby
   build-docker-cli:
     cmds:
@@ -74,6 +74,27 @@ tasks:
       - mkdir -p ../bin
       - docker cp usernetes-build-docker-cli:/usr/local/bin/docker ../bin
       - docker rm -f usernetes-build-docker-cli
+  build-containerd:
+    cmds:
+      - |
+        docker build -t usernetes-build-containerd -f containerd.Dockerfile \
+        --build-arg RUNC_COMMIT={{.RUNC_COMMIT}} .
+      - mkdir -p ../bin
+      - docker run --rm usernetes-build-containerd sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
+  build-runc:
+    cmds:
+      - |
+        docker build -t usernetes-build-runc -f runc.Dockerfile \
+        --build-arg CONTAINERD_COMMIT={{.CONTAINERD_COMMIT}} .
+      - mkdir -p ../bin
+      - docker run --rm usernetes-build-runc sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
+  build-cni:
+    cmds:
+      - |
+        docker build -t usernetes-build-cni -f cni.Dockerfile \
+        --build-arg CNI_PLUGINS_COMMIT={{.CNI_PLUGINS_COMMIT}} .
+      - mkdir -p ../bin
+      - docker run --rm usernetes-build-cni sh -c 'cd /out; tar chf - *' | tar Cxvf ../bin -
   build-kubernetes:
     cmds:
       - docker rm -f usernetes-build-kubernetes 2> /dev/null || true
@@ -103,6 +124,6 @@ tasks:
       - mkdir -p ../_artifact
       - ( cd .. ; tar --transform 's@^\.@usernetes@' --exclude-vcs --exclude=./_artifact -cjvf ./_artifact/usernetes-x86_64.tbz . )
   default:
-    deps: [build-rootlesskit,build-slirp4netns,build-moby,build-docker-cli,build-crio,build-kubernetes,build-etcd,build-go-task]
+    deps: [build-rootlesskit,build-slirp4netns,build-moby,build-docker-cli,build-containerd,build-runc,build-cni,build-crio,build-kubernetes,build-etcd,build-go-task]
     cmds:
       - task: build-artifact

--- a/build/cni.Dockerfile
+++ b/build/cni.Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.11-alpine
+RUN apk add --no-cache bash build-base git linux-headers
+RUN git clone https://github.com/containernetworking/plugins.git /go/src/github.com/containernetworking/plugins
+WORKDIR /go/src/github.com/containernetworking/plugins
+ARG CNI_PLUGINS_COMMIT
+RUN git pull && git checkout ${CNI_PLUGINS_COMMIT}
+RUN ./build.sh -buildmode pie -ldflags "-extldflags \"-fno-PIC -static\"" && \
+  mkdir -p /out/cni && cp -f bin/* /out/cni

--- a/build/containerd.Dockerfile
+++ b/build/containerd.Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.11-alpine
+RUN apk add --no-cache btrfs-progs-dev build-base git
+RUN git clone https://github.com/containerd/containerd.git /go/src/github.com/containerd/containerd
+WORKDIR /go/src/github.com/containerd/containerd
+ARG CONTAINERD_COMMIT
+RUN git pull && git checkout ${CONTAINERD_COMMIT}
+RUN make EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' BUILDTAGS="netgo osusergo static_build" && \
+  mkdir -p /out && cp -f bin/containerd bin/containerd-shim bin/containerd-shim-runc-v1 bin/ctr /out

--- a/build/crio.Dockerfile
+++ b/build/crio.Dockerfile
@@ -2,38 +2,9 @@
 # TODO: use Alpine again when we figure out how to build cri-o as a static binary (rootless-containers/usernetes#19)
 FROM golang:1.11 AS base
 RUN apt-get update && apt-get install -y build-essential libglib2.0-dev
-ARG CRIO_COMMIT
-ARG RUNC_COMMIT
-ARG CNI_PLUGINS_COMMIT
-
-FROM base as cri-o
 RUN git clone https://github.com/kubernetes-incubator/cri-o.git /go/src/github.com/kubernetes-incubator/cri-o
 WORKDIR /go/src/github.com/kubernetes-incubator/cri-o
+ARG CRIO_COMMIT
 RUN git pull && git checkout ${CRIO_COMMIT}
 RUN make BUILDTAGS="exclude_graphdriver_btrfs exclude_graphdriver_devicemapper containers_image_openpgp" binaries && \
-  mkdir -p /crio/cni/plugins/ /crio/cni/conf && \
-  mkdir -p /crio/cni && \
-  cp bin/conmon bin/crio /crio && \
-  cp contrib/cni/* /crio/cni/conf
-
-FROM base AS cni
-RUN git clone https://github.com/containernetworking/plugins /go/src/github.com/containernetworking/plugins
-WORKDIR /go/src/github.com/containernetworking/plugins
-RUN git pull && git checkout ${CNI_PLUGINS_COMMIT}
-RUN ./build.sh -ldflags "-extldflags -static" && \
-  mkdir -p /crio/cni/plugins && \
-  cp bin/* /crio/cni/plugins
-
-FROM base AS runc
-RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc
-WORKDIR /go/src/github.com/opencontainers/runc
-RUN git pull && git checkout ${RUNC_COMMIT}
-RUN make BUILDTAGS="" SHELL=/bin/sh static && \
-  mkdir -p /crio && \
-  cp runc /crio
-
-FROM base
-RUN mkdir -p /crio
-COPY --from=cri-o /crio/ /crio/
-COPY --from=cni /crio/ /crio/
-COPY --from=runc /crio/ /crio/
+  mkdir -p /out && cp -f bin/conmon bin/crio /out

--- a/build/moby.Dockerfile
+++ b/build/moby.Dockerfile
@@ -1,7 +1,7 @@
-FROM docker:18.09.0-rc1-dind
-RUN apk --no-cache add bash make git
-RUN git clone https://github.com/moby/moby.git /moby
-WORKDIR /moby
+FROM golang:1.11-alpine AS moby-base
+RUN apk --no-cache add btrfs-progs-dev bash build-base git libseccomp-dev
+RUN git clone https://github.com/moby/moby.git /go/src/github.com/docker/docker
+WORKDIR /go/src/github.com/docker/docker
 ARG MOBY_COMMIT
 RUN git pull && git checkout ${MOBY_COMMIT}
 COPY ./patches/moby /patches
@@ -9,3 +9,17 @@ COPY ./patches/moby /patches
 RUN git config user.email "nobody@example.com" && \
   git config user.name "Usernetes Build Script" && \
   git am /patches/* && git show --summary
+
+FROM moby-base AS docker-init
+RUN apk --no-cache add cmake
+RUN hack/dockerfile/install/install.sh tini
+
+FROM moby-base AS docker-proxy
+RUN hack/dockerfile/install/install.sh proxy
+
+FROM moby-base
+RUN mkdir -p /out
+COPY --from=docker-init /usr/local/bin/docker-init /out/
+COPY --from=docker-proxy /usr/local/bin/docker-proxy /out/
+ENV DOCKER_BUILDTAGS="seccomp"
+RUN ./hack/make.sh .binary && cp -f bundles/.binary/dockerd-dev /out/dockerd

--- a/build/rootlesskit.Dockerfile
+++ b/build/rootlesskit.Dockerfile
@@ -4,4 +4,7 @@ RUN git clone https://github.com/rootless-containers/rootlesskit.git /go/src/git
 WORKDIR /go/src/github.com/rootless-containers/rootlesskit
 ARG ROOTLESSKIT_COMMIT
 RUN git pull && git checkout ${ROOTLESSKIT_COMMIT}
-RUN CGO_ENABLED=0 go build -o /rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit
+ENV CGO_ENABLED=0
+RUN mkdir -p /out && \
+  go build -o /out/rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit && \
+  go build -o /out/rootlessctl github.com/rootless-containers/rootlesskit/cmd/rootlessctl

--- a/build/runc.Dockerfile
+++ b/build/runc.Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.11-alpine
+RUN apk add --no-cache bash build-base git libseccomp-dev linux-headers
+RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc
+WORKDIR /go/src/github.com/opencontainers/runc
+ARG RUNC_COMMIT
+RUN git pull && git checkout ${RUNC_COMMIT}
+RUN make BUILDTAGS="seccomp" static && \
+  mkdir -p /out && cp -f runc /out

--- a/build/slirp4netns.Dockerfile
+++ b/build/slirp4netns.Dockerfile
@@ -4,4 +4,5 @@ RUN git clone https://github.com/rootless-containers/slirp4netns.git /slirp4netn
 WORKDIR /slirp4netns
 ARG SLIRP4NETNS_COMMIT
 RUN git pull && git checkout ${SLIRP4NETNS_COMMIT}
-RUN ./autogen.sh && ./configure LDFLAGS="-static" && make
+RUN ./autogen.sh && ./configure LDFLAGS="-static" && make && \
+  mkdir -p /out && cp -f slirp4netns /out

--- a/config/crio/cni/10-cri-bridge.conf
+++ b/config/crio/cni/10-cri-bridge.conf
@@ -1,0 +1,15 @@
+{
+    "cniVersion": "0.3.0",
+    "name": "crio-bridge",
+    "type": "bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.88.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}

--- a/config/crio/cni/99-loopback.conf
+++ b/config/crio/cni/99-loopback.conf
@@ -1,0 +1,4 @@
+{
+    "cniVersion": "0.3.0",
+    "type": "loopback"
+}


### PR DESCRIPTION
Preparation for adding containerd CRI

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

---

Before:
```
bin
├── crio
│   ├── cni
│   │   ├── conf
│   │   │   ├── 10-crio-bridge.conf
│   │   │   ├── 99-loopback.conf
│   │   │   └── README.md
│   │   └── plugins
│   │       ├── bandwidth
│   │       ├── bridge
│   │       ├── dhcp
│   │       ├── flannel
│   │       ├── host-device
│   │       ├── host-local
│   │       ├── ipvlan
│   │       ├── loopback
│   │       ├── macvlan
│   │       ├── portmap
│   │       ├── ptp
│   │       ├── sample
│   │       ├── static
│   │       ├── tuning
│   │       └── vlan
│   ├── conmon
│   ├── crio
│   └── runc
├── docker
├── etcd
├── etcdctl
├── hyperkube
├── moby
│   ├── containerd
│   ├── containerd-shim
│   ├── ctr
│   ├── docker-init
│   ├── docker-proxy
│   ├── dockerd
│   └── runc
├── rootlesskit
├── slirp4netns
└── task
```


After:
```
bin
├── cni
│   ├── bandwidth
│   ├── bridge
│   ├── dhcp
│   ├── flannel
│   ├── host-device
│   ├── host-local
│   ├── ipvlan
│   ├── loopback
│   ├── macvlan
│   ├── portmap
│   ├── ptp
│   ├── sample
│   ├── static
│   ├── tuning
│   └── vlan
├── conmon
├── containerd
├── containerd-shim
├── containerd-shim-runc-v1
├── crio
├── ctr
├── dockerd
├── docker-init
├── docker-proxy
├── etcd
├── etcdctl
├── hyperkube
├── rootlessctl
├── rootlesskit
├── runc
├── slirp4netns
└── task
config/
└── crio
    └── cni
        ├── 10-cri-bridge.conf
        └── 99-loopback.conf
```