### PR TITLE
boot/dockerd.sh: use vfs storage driver on non-Ubuntu

### DIFF
--- a/boot/containerd.sh
+++ b/boot/containerd.sh
@@ -16,8 +16,7 @@ state = "$XDG_RUNTIME_DIR/containerd"
     disable_apparmor = true
     restrict_oom_score_adj = true
     [plugins.cri.containerd]
-    # If you are on Ubuntu you can use "overlayfs". Otherwise you need to use "native".
-      snapshotter = "$( (uname -v | grep Ubuntu >/dev/null) && echo overlayfs || echo native)"
+      snapshotter = "$( overlayfs::supported && echo overlayfs || echo native )"
     [plugins.cri.cni]
       bin_dir = "$U7S_BASE_DIR/bin/cni"
       conf_dir = "$U7S_BASE_DIR/config/containerd/cni"

--- a/boot/dockerd.sh
+++ b/boot/dockerd.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 source $(dirname $0)/../common/common.inc.sh
 
-exec $(dirname $0)/nsenter.sh dockerd --experimental $@
+exec $(dirname $0)/nsenter.sh dockerd \
+	--experimental \
+	--storage-driver $(overlayfs::supported && echo overlay2 || echo vfs) \
+	$@

--- a/common/common.inc.sh
+++ b/common/common.inc.sh
@@ -88,6 +88,13 @@ function nsenter::_nsenter() {
 	nsenter -U --preserve-credential -n -m -t $(cat $pidfile) --wd=$PWD -- $@
 }
 
+## overlayfs utilities
+function overlayfs::supported() {
+	rc=0
+	(uname -v | grep Ubuntu >/dev/null) || rc=$?
+	return rc
+}
+
 # entrypoint begins
 if debug::enabled; then
 	log::warning "Running in debug mode (\$U7S_DEBUG)"


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>