### PR TITLE
update components (CVE-2019-5736, CVE-2019-6778)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,30 +2,30 @@
 # $ ./hack/translate-dockerfile-runopt-directive.sh < Dockerfile  | DOCKER_BUILDKIT=1 docker build  -f -  .
 
 ### Version definitions
-# 1/14/2019 (v0.3.0-alpha.0)
-ARG ROOTLESSKIT_COMMIT=3c4582e950e3a67795c2832179c125b258b78124
-# 1/12/2019 (v0.3.0-alpha.0)
-ARG SLIRP4NETNS_COMMIT=d013231cdc6607788be81599017f9199f634fe0b
-# 12/20/2018
-ARG RUNC_COMMIT=bbb17efcb4c0ab986407812a31ba333a7450064c
-# 02/03/2019
-ARG MOBY_COMMIT=93d994e29c9cc8d81f1b0477e28d705fa7e2cd72
-ARG DOCKER_CLI_RELEASE=18.09.1-rc1
-# 02/01/2019
-ARG CONTAINERD_COMMIT=6b25c1e45c2b8246dba17de3b1d574f6720ce79f
-# 01/07/2019
-ARG CRIO_COMMIT=650fae1c52ff809c8447fd6dcdc1e9e3747efe65
-# 12/20/2018
-ARG CNI_PLUGINS_COMMIT=ee819c71a17d50f27439dbd979337effb2efd21b
-# 01/07/2019
-ARG KUBERNETES_COMMIT=8b3b5a9fe7b57cfe014927d575a9ad90cb536419
+# 02/05/2019 (v0.3.0-alpha.1)
+ARG ROOTLESSKIT_COMMIT=7905ee34b3d9d1f27fe2ffa3c5fd3d01bb3644dd
+# 01/26/2019 (v0.3.0-alpha.2)
+ARG SLIRP4NETNS_COMMIT=30883b5aef81510915ca0e0b28072e809172e1f6
+# 02/08/2019
+ARG RUNC_COMMIT=6635b4f0c6af3810594d2770f662f34ddc15b40d
+# 02/11/2019
+ARG MOBY_COMMIT=f18cf23e97b01855d210eb497494fef8ac511073
+ARG DOCKER_CLI_RELEASE=18.09.1
+# 02/11/2019
+ARG CONTAINERD_COMMIT=b02ab6c742a48d5ea0ebadaa3c18329356a383a4
+# 02/05/2019
+ARG CRIO_COMMIT=3b9de7a5d2115ee8968ef04fa26f5125efbb71f5
+# 02/07/2018
+ARG CNI_PLUGINS_COMMIT=1865a0701ec6c6fae796344001333b4fda7a8701
+# 02/11/2019
+ARG KUBERNETES_COMMIT=6671d2556f1af67e703c329b1186896d7c6f9f4d
 # Kube's build script requires KUBE_GIT_VERSION to be set to a semver string
 ARG KUBE_GIT_VERSION=v1.14-usernetes
-ARG BAZEL_RELEASE=0.21.0
+ARG BAZEL_RELEASE=0.22.0
 # 01/23/2017 (v.1.7.3.2)
 ARG SOCAT_COMMIT=cef0e039a89fe3b38e36090d9fe4be000973e0be
-ARG FLANNEL_RELEASE=v0.10.0
-ARG ETCD_RELEASE=v3.3.11
+ARG FLANNEL_RELEASE=v0.11.0
+ARG ETCD_RELEASE=v3.3.12
 ARG GOTASK_RELEASE=v2.3.0
 
 ARG BASEOS=ubuntu
@@ -165,7 +165,7 @@ RUN mkdir -p /out && \
 FROM busybox AS etcd-build
 ARG ETCD_RELEASE
 RUN mkdir /tmp-etcd out && \
-  wget -O - https://github.com/etcd-io/etcd/releases/download/v3.3.11/etcd-${ETCD_RELEASE}-linux-amd64.tar.gz | tar xz -C /tmp-etcd && \
+  wget -O - https://github.com/etcd-io/etcd/releases/download/${ETCD_RELEASE}/etcd-${ETCD_RELEASE}-linux-amd64.tar.gz | tar xz -C /tmp-etcd && \
   cp /tmp-etcd/etcd-${ETCD_RELEASE}-linux-amd64/etcd /tmp-etcd/etcd-${ETCD_RELEASE}-linux-amd64/etcdctl /out
 
 #### go-task (gotask-build)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usernetes aims to provide a binary distribution of Moby (aka Docker) and Kuberne
 
 Currently, Usernetes uses our patched version of Moby and Kubernetes. See [`./src/patches`](./src/patches).
 
-Deployment shell scripts are in POC status.
+Deployment shell scripts are in POC status. (It even lacks TLS setup - [#76](https://github.com/rootless-containers/usernetes/issues/76))
 
 ## How it works
 

--- a/src/patches/kubernetes/0001-kubelet-cm-ignore-sysctl-error-when-running-in-usern.patch
+++ b/src/patches/kubernetes/0001-kubelet-cm-ignore-sysctl-error-when-running-in-usern.patch
@@ -1,4 +1,4 @@
-From bf873c404db4d7746fba8c2c7ea6b4309aaef771 Mon Sep 17 00:00:00 2001
+From a3dbe0547f5680b2440fb83954d9e1bb3f026424 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Date: Tue, 21 Aug 2018 16:45:04 +0900
 Subject: [PATCH 1/4] kubelet/cm: ignore sysctl error when running in userns
@@ -10,19 +10,19 @@ Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/pkg/kubelet/cm/BUILD b/pkg/kubelet/cm/BUILD
-index e6e44b4435..9db678e396 100644
+index 353b7c641a..2e18c281c8 100644
 --- a/pkg/kubelet/cm/BUILD
 +++ b/pkg/kubelet/cm/BUILD
-@@ -88,6 +88,7 @@ go_library(
+@@ -87,6 +87,7 @@ go_library(
              "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
              "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd:go_default_library",
              "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
 +            "//vendor/github.com/opencontainers/runc/libcontainer/system:go_default_library",
+             "//vendor/k8s.io/utils/path:go_default_library",
          ],
          "@io_bazel_rules_go//go/platform:nacl": [
-             "//pkg/kubelet/cadvisor:go_default_library",
 diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
-index ea0a5ad215..9b48945cc7 100644
+index af7a779173..c788fa4446 100644
 --- a/pkg/kubelet/cm/container_manager_linux.go
 +++ b/pkg/kubelet/cm/container_manager_linux.go
 @@ -32,6 +32,7 @@ import (

--- a/src/patches/kubernetes/0002-dockershim-ignore-GetCheckpoint-error-when-running-i.patch
+++ b/src/patches/kubernetes/0002-dockershim-ignore-GetCheckpoint-error-when-running-i.patch
@@ -1,4 +1,4 @@
-From b097264fc7d80611e812ed7591722ecfc603cdcd Mon Sep 17 00:00:00 2001
+From b55c4a76fcc8fa6097c002635cd65dc0f53345d8 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Date: Tue, 21 Aug 2018 16:48:27 +0900
 Subject: [PATCH 2/4] dockershim: ignore GetCheckpoint error when running in

--- a/src/patches/kubernetes/0003-POC-kubelet-cm-ignore-cgroups-error-when-running-in-.patch
+++ b/src/patches/kubernetes/0003-POC-kubelet-cm-ignore-cgroups-error-when-running-in-.patch
@@ -1,4 +1,4 @@
-From 096dda66f267d14b0624630b4db4e1826e900722 Mon Sep 17 00:00:00 2001
+From febdd28926ff0d8241cf403d6bbe1e013e81ada5 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Date: Tue, 21 Aug 2018 16:49:14 +0900
 Subject: [PATCH 3/4] [POC] kubelet/cm: ignore cgroups error when running in
@@ -22,19 +22,19 @@ Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
  9 files changed, 56 insertions(+), 13 deletions(-)
 
 diff --git a/pkg/kubelet/BUILD b/pkg/kubelet/BUILD
-index 61e9e649ed..1fd6c0d1df 100644
+index 4f2779ed86..9fb46f4ebe 100644
 --- a/pkg/kubelet/BUILD
 +++ b/pkg/kubelet/BUILD
-@@ -149,6 +149,7 @@ go_library(
+@@ -146,6 +146,7 @@ go_library(
          "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
          "//vendor/github.com/google/cadvisor/info/v2:go_default_library",
          "//vendor/k8s.io/klog:go_default_library",
 +        "//vendor/github.com/opencontainers/runc/libcontainer/system:go_default_library",
          "//vendor/k8s.io/utils/exec:go_default_library",
-     ],
- )
+         "//vendor/k8s.io/utils/integer:go_default_library",
+         "//vendor/k8s.io/utils/path:go_default_library",
 diff --git a/pkg/kubelet/cm/cgroup_manager_linux.go b/pkg/kubelet/cm/cgroup_manager_linux.go
-index f1c8136936..80a406c2a9 100644
+index 2eb2a167f7..9ad975782f 100644
 --- a/pkg/kubelet/cm/cgroup_manager_linux.go
 +++ b/pkg/kubelet/cm/cgroup_manager_linux.go
 @@ -29,6 +29,7 @@ import (
@@ -57,7 +57,7 @@ index f1c8136936..80a406c2a9 100644
  		}, nil
  	case libcontainerSystemd:
  		// this means you asked systemd to manage cgroups, but systemd was not on the host, so all you can do is panic...
-@@ -476,7 +478,9 @@ func (m *cgroupManagerImpl) Create(cgroupConfig *CgroupConfig) error {
+@@ -478,7 +480,9 @@ func (m *cgroupManagerImpl) Create(cgroupConfig *CgroupConfig) error {
  	// in the tasks file. We use the function to create all the required
  	// cgroup files but not attach any "real" pid to the cgroup.
  	if err := manager.Apply(-1); err != nil {
@@ -69,7 +69,7 @@ index f1c8136936..80a406c2a9 100644
  
  	// it may confuse why we call set after we do apply, but the issue is that runc
 diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
-index 9b48945cc7..4473ed6050 100644
+index c788fa4446..81e9eb9331 100644
 --- a/pkg/kubelet/cm/container_manager_linux.go
 +++ b/pkg/kubelet/cm/container_manager_linux.go
 @@ -467,13 +467,20 @@ func (cm *containerManagerImpl) setupNode(activePods ActivePodsFunc) error {
@@ -96,7 +96,7 @@ index 9b48945cc7..4473ed6050 100644
  			}
  			cont, err := getContainer(os.Getpid())
 diff --git a/pkg/kubelet/cm/qos_container_manager_linux.go b/pkg/kubelet/cm/qos_container_manager_linux.go
-index cebc9756e4..533db5a56b 100644
+index 7f956a776a..86604b0ce9 100644
 --- a/pkg/kubelet/cm/qos_container_manager_linux.go
 +++ b/pkg/kubelet/cm/qos_container_manager_linux.go
 @@ -28,6 +28,7 @@ import (
@@ -118,7 +118,7 @@ index cebc9756e4..533db5a56b 100644
  	}
  
  	// Top level for Qos containers are created only for Burstable
-@@ -327,15 +330,23 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
+@@ -323,15 +326,23 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
  		}
  	}
  
@@ -182,7 +182,7 @@ index b59c6a0836..77fb9b87bb 100644
  }
  
 diff --git a/pkg/kubelet/kubelet.go b/pkg/kubelet/kubelet.go
-index 7fafae4109..0ff3aa394a 100644
+index bb00c21a94..5a29016286 100644
 --- a/pkg/kubelet/kubelet.go
 +++ b/pkg/kubelet/kubelet.go
 @@ -33,6 +33,7 @@ import (
@@ -193,7 +193,7 @@ index 7fafae4109..0ff3aa394a 100644
  	"k8s.io/api/core/v1"
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/apimachinery/pkg/fields"
-@@ -1586,10 +1587,13 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
+@@ -1583,10 +1584,13 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
  				break
  			}
  		}
@@ -208,7 +208,7 @@ index 7fafae4109..0ff3aa394a 100644
  			if err := kl.killPod(pod, nil, podStatus, nil); err == nil {
  				podKilled = true
  			}
-@@ -1608,7 +1612,9 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
+@@ -1605,7 +1609,9 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
  				}
  				if err := pcm.EnsureExists(pod); err != nil {
  					kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToCreatePodContainer, "unable to ensure pod container exists: %v", err)

--- a/src/patches/kubernetes/0004-kube-proxy-allow-running-in-userns.patch
+++ b/src/patches/kubernetes/0004-kube-proxy-allow-running-in-userns.patch
@@ -1,4 +1,4 @@
-From 5201fc1623b51d4dacfd67d43bfda202de24b4b4 Mon Sep 17 00:00:00 2001
+From 6c44e6f9dae2833b8b7bffb4049568846ca1a743 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Date: Thu, 23 Aug 2018 14:14:44 +0900
 Subject: [PATCH 4/4] kube-proxy: allow running in userns
@@ -12,13 +12,13 @@ Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
  4 files changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/cmd/kube-proxy/app/BUILD b/cmd/kube-proxy/app/BUILD
-index f76d454296..4e05482267 100644
+index 75052c2ded..2e996668cb 100644
 --- a/cmd/kube-proxy/app/BUILD
 +++ b/cmd/kube-proxy/app/BUILD
-@@ -62,6 +62,7 @@ go_library(
-         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
-         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+@@ -65,6 +65,7 @@ go_library(
+         "//staging/src/k8s.io/component-base/config:go_default_library",
          "//staging/src/k8s.io/kube-proxy/config/v1alpha1:go_default_library",
+         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
 +        "//vendor/github.com/opencontainers/runc/libcontainer/system:go_default_library",
          "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
          "//vendor/github.com/spf13/cobra:go_default_library",


### PR DESCRIPTION
* CVE-2019-5736: https://github.com/opencontainers/runc/commit/0a8e4117e7f715d5fbeef398405813ce8e88558b
* CVE-2019-6778: https://github.com/rootless-containers/slirp4netns/commit/d7811709dbd63f3bb93de37ec803d22ff213ae14

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>