### PR TITLE
use crun instead of runc

### DIFF
--- a/boot/containerd.sh
+++ b/boot/containerd.sh
@@ -5,20 +5,25 @@ nsenter::main $0 $@
 
 mkdir -p $XDG_RUNTIME_DIR/usernetes
 cat >$XDG_RUNTIME_DIR/usernetes/containerd.toml <<EOF
+version = 2
 root = "$XDG_DATA_HOME/containerd"
 state = "$XDG_RUNTIME_DIR/containerd"
 [grpc]
   address = "$XDG_RUNTIME_DIR/containerd/containerd.sock"
 [plugins]
-  [plugins.linux]
-    runtime_root = "$XDG_RUNTIME_DIR/containerd/runc"
-  [plugins.cri]
+  [plugins."io.containerd.grpc.v1.cri"]
     disable_cgroup = true
     disable_apparmor = true
     restrict_oom_score_adj = true
-    [plugins.cri.containerd]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "$(overlayfs::supported && echo overlayfs || echo native)"
-    [plugins.cri.cni]
+      default_runtime_name = "crun"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun.options]
+            BinaryName = "crun"
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"
 EOF

--- a/boot/crio.sh
+++ b/boot/crio.sh
@@ -11,6 +11,15 @@ mkdir -p $XDG_DATA_HOME/containers/oci/hooks.d $XDG_CONFIG_HOME/containers $XDG_
 if [[ ! -f $XDG_CONFIG_HOME/crio/crio.conf ]]; then
 	cat >$XDG_CONFIG_HOME/crio/crio.conf <<EOF
 registries = ['registry.access.redhat.com', 'registry.fedoraproject.org', 'docker.io']
+[crio.runtime]
+  default_runtime = "crun"
+  [crio.runtime.runtimes]
+    [crio.runtime.runtimes.crun]
+      runtime_path = "$U7S_BASE_DIR/bin/crun"
+      runtime_root = "$XDG_RUNTIME_DIR/crio/crun"
+# Dummy runc handler, as a workaround of https://github.com/cri-o/cri-o/issues/3360
+    [crio.runtime.runtimes.runc]
+      runtime_path = "/bin/false"
 EOF
 fi
 
@@ -27,7 +36,6 @@ exec crio \
 	--registry registry.access.redhat.com --registry registry.fedoraproject.org --registry docker.io \
 	--conmon $U7S_BASE_DIR/bin/conmon \
 	--runroot $XDG_RUNTIME_DIR/crio \
-	--runtimes runc:$U7S_BASE_DIR/bin/runc:$XDG_RUNTIME_DIR/crio/runc \
 	--cni-config-dir /etc/cni/net.d \
 	--cni-plugin-dir /opt/cni/bin \
 	--root $XDG_DATA_HOME/containers/storage \

--- a/hack/show-latest-commits.sh
+++ b/hack/show-latest-commits.sh
@@ -14,7 +14,6 @@ x() {
 
 x ROOTLESSKIT rootless-containers/rootlesskit
 x SLIRP4NETNS rootless-containers/slirp4netns
-x RUNC opencontainers/runc
 x CONTAINERD containerd/containerd
 x CRIO cri-o/cri-o
 x KUBERNETES kubernetes/kubernetes

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ function usage() {
 	echo
 	echo "Examples:"
 	echo "  # The default options"
-	echo "  ${arg0}
+	echo "  ${arg0}"
 	echo
 	echo "  # Use CRI-O as the CRI runtime"
 	echo "  ${arg0} --cri=crio"


### PR DESCRIPTION
Switching to crun, as crun is the defacto reference implementation of OCI for cgroup v2.
