### PR TITLE
support `--cgroup-manager=systemd` (requires cgroup v2 and containerd)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,9 +22,9 @@ jobs:
       run: |
         make clean
         docker builder prune -a -f
-    - name: "Smoke test (containerd)"
+    - name: "Smoke test (containerd, w/o cgroups)"
       run: ./hack/smoketest-docker.sh u7s-test-containerd rootlesscontainers/usernetes --cri=containerd
-    - name: "Smoke test (CRI-O)"
+    - name: "Smoke test (CRI-O, w/o cgroups)"
       run: ./hack/smoketest-docker.sh u7s-test-crio rootlesscontainers/usernetes --cri=crio
     - name: "Smoke test (multi-node cluster with Flannel)"
       run: ./hack/smoketest-docker-compose.sh
@@ -47,7 +47,9 @@ jobs:
         vagrant up
         mkdir -p ~/.ssh
         vagrant ssh-config >> ~/.ssh/config
-    - name: "Smoke test (containerd)"
+    - name: "Smoke test (containerd, w/o cgroups)"
       run: ssh default /vagrant/hack/smoketest-binaries.sh --cri=containerd
-    - name: "Smoke test (CRI-O)"
+    - name: "Smoke test (containerd, with systemd cgroup manager)"
+      run: ssh default /vagrant/hack/smoketest-binaries.sh --cri=containerd --cgroup-manager=systemd
+    - name: "Smoke test (CRI-O, w/o cgroups)"
       run: ssh default /vagrant/hack/smoketest-binaries.sh --cri=crio

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,11 @@ RUN git clone https://github.com/containerd/containerd.git /go/src/github.com/co
 WORKDIR /go/src/github.com/containerd/containerd
 ARG CONTAINERD_COMMIT
 RUN git pull && git checkout ${CONTAINERD_COMMIT}
+COPY ./src/patches/containerd /patches
+# `git am` requires user info to be set
+RUN git config user.email "nobody@example.com" && \
+  git config user.name "Usernetes Build Script" && \
+  git am /patches/* && git show --summary
 ENV GO111MODULE=off
 RUN make --quiet EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' BUILDTAGS="netgo osusergo static_build no_devmapper no_btrfs no_aufs no_zfs" \
   bin/containerd bin/containerd-shim-runc-v2 bin/ctr && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,17 @@ Vagrant.configure("2") do |config|
     v.cpus = 2
   end
   config.vm.provision "shell", inline: <<-SHELL
-    dnf install -y iptables
+    dnf install -y iptables jq
+
+    # Delegate cgroup v2 controllers
+    mkdir -p /etc/systemd/system/user@.service.d
+    cat > /etc/systemd/system/user@.service.d/delegate.conf << EOF
+[Service]
+# default: Delegate=pids memory
+# NOTE: delegation of cpuset requires systemd >= 244 (Fedora >= 32, Ubuntu >= 20.04). cpuset is ignored on Fedora 31.
+Delegate=cpu cpuset io memory pids
+EOF
+    systemctl daemon-reload
+
   SHELL
 end

--- a/boot/containerd.sh
+++ b/boot/containerd.sh
@@ -3,6 +3,14 @@ export U7S_BASE_DIR=$(realpath $(dirname $0)/..)
 source $U7S_BASE_DIR/common/common.inc.sh
 nsenter::main $0 $@
 
+disable_cgroup="true"
+systemd_cgroup="false"
+: ${U7S_CGROUP_MANAGER=}
+if [[ $U7S_CGROUP_MANAGER == "systemd" ]]; then
+	disable_cgroup="false"
+	systemd_cgroup="true"
+fi
+
 mkdir -p $XDG_RUNTIME_DIR/usernetes
 cat >$XDG_RUNTIME_DIR/usernetes/containerd.toml <<EOF
 version = 2
@@ -16,9 +24,10 @@ state = "$XDG_RUNTIME_DIR/usernetes/containerd"
     address = "$XDG_RUNTIME_DIR/usernetes/containerd/fuse-overlayfs.sock"
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    disable_cgroup = true
+    disable_cgroup = ${disable_cgroup}
     disable_apparmor = true
     restrict_oom_score_adj = true
+    disable_hugepages_cgroup_controller = true
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "fuse-overlayfs"
       default_runtime_name = "crun"
@@ -27,6 +36,7 @@ state = "$XDG_RUNTIME_DIR/usernetes/containerd"
           runtime_type = "io.containerd.runc.v2"
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun.options]
             BinaryName = "crun"
+            SystemdCgroup = ${systemd_cgroup}
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"

--- a/boot/crio.sh
+++ b/boot/crio.sh
@@ -4,6 +4,13 @@ source $U7S_BASE_DIR/common/common.inc.sh
 nsenter::main $0 $@
 
 export _CRIO_ROOTLESS=1
+
+: ${U7S_CGROUP_MANAGER=}
+if [[ $U7S_CGROUP_MANAGER == "systemd" ]]; then
+	log::error "CRI-O does not support systemd cgroup manager"
+	exit 1
+fi
+
 mkdir -p $XDG_CONFIG_HOME/usernetes/crio $XDG_CONFIG_HOME/usernetes/containers/oci/hooks.d
 
 cat >$XDG_CONFIG_HOME/usernetes/containers/policy.json <<EOF

--- a/boot/kubelet.sh
+++ b/boot/kubelet.sh
@@ -2,6 +2,11 @@
 export U7S_BASE_DIR=$(realpath $(dirname $0)/..)
 source $U7S_BASE_DIR/common/common.inc.sh
 
+: ${U7S_CGROUP_MANAGER=}
+if [[ $U7S_CGROUP_MANAGER == "" ]]; then
+	U7S_CGROUP_MANAGER="none"
+fi
+
 mkdir -p $XDG_RUNTIME_DIR/usernetes
 cat >$XDG_RUNTIME_DIR/usernetes/kubelet-config.yaml <<EOF
 kind: KubeletConfiguration
@@ -19,12 +24,14 @@ clusterDNS:
   - "10.0.0.53"
 failSwapOn: false
 featureGates:
-  DevicePlugins: false
+  Rootless: true
   SupportNoneCgroupDriver: true
+  DevicePlugins: false
   LocalStorageCapacityIsolation: false
 evictionHard:
   nodefs.available: "3%"
-cgroupDriver: none
+rootless: true
+cgroupDriver: $U7S_CGROUP_MANAGER
 cgroupsPerQOS: false
 enforceNodeAllocatable: []
 EOF

--- a/boot/rootlesskit.sh
+++ b/boot/rootlesskit.sh
@@ -31,13 +31,14 @@ if [[ $_U7S_CHILD == 0 ]]; then
 	# * /run: copy-up is required so that we can create /run/* in our namespace
 	# * /var/lib: copy-up is required for several Kube stuff
 	# * /opt: copy-up is required for mounting /opt/cni/bin
+	#
+	# We do NOT specify --pidns, as it is incompatible with systemd cgroup manager.
 	rootlesskit \
 		--state-dir $rk_state_dir \
 		--net=slirp4netns --mtu=65520 --disable-host-loopback --slirp4netns-sandbox=true --slirp4netns-seccomp=true \
 		--port-driver=builtin \
 		--copy-up=/etc --copy-up=/run --copy-up=/var/lib --copy-up=/opt \
 		--propagation=rslave \
-		--pidns \
 		$U7S_ROOTLESSKIT_FLAGS \
 		$0 $@
 else

--- a/common/common.inc.sh
+++ b/common/common.inc.sh
@@ -86,7 +86,7 @@ function nsenter::_nsenter() {
 	fi
 	export ROOTLESSKIT_STATE_DIR=$XDG_RUNTIME_DIR/usernetes/rootlesskit
 	# TODO(AkihiroSuda): ping to $XDG_RUNTIME_DIR/usernetes/rootlesskit/api.sock
-	nsenter -U --preserve-credential -n -m -p -t $(cat $pidfile) --wd=$PWD -- $@
+	nsenter -U --preserve-credential -n -m -t $(cat $pidfile) --wd=$PWD -- $@
 }
 
 # entrypoint begins

--- a/hack/smoketest-binaries.sh
+++ b/hack/smoketest-binaries.sh
@@ -37,3 +37,7 @@ if ! timeout 60 kubectl run --rm -i --image busybox --restart=Never hello echo h
 fi
 
 smoketest_dns
+
+if grep -q 'U7S_CGROUP_MANAGER=.*systemd.*' ~/.config/usernetes/env; then
+	smoketest_limits
+fi

--- a/hack/smoketest-manifests/test-limits.yaml
+++ b/hack/smoketest-manifests/test-limits.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-limits
+spec:
+  containers:
+  - name: test-limits
+    image: alpine
+    command: ["top"]
+    resources:
+      limits:
+        cpu: 420m
+        memory: 42Mi

--- a/src/patches/containerd/0001-DIRTY-VENDOR-cri-allow-disabling-hugepages.patch
+++ b/src/patches/containerd/0001-DIRTY-VENDOR-cri-allow-disabling-hugepages.patch
@@ -1,0 +1,138 @@
+From 62a4c184c8537c7657084e4eaea3fb9ab69ae063 Mon Sep 17 00:00:00 2001
+From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Date: Wed, 1 Jul 2020 18:27:50 +0900
+Subject: [PATCH] [DIRTY VENDOR] cri: allow disabling hugepages
+
+This helps with running rootless mode + cgroup v2 + systemd without hugetlb delegation.
+Systemd does not support hugetlb delegation as of systemd v245.
+
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+---
+ .../containerd/cri/pkg/config/config.go       |  4 +++
+ .../containerd/cri/pkg/config/config_unix.go  |  1 +
+ .../cri/pkg/containerd/opts/spec_unix.go      | 28 ++++++++++---------
+ .../cri/pkg/server/container_create_unix.go   |  2 +-
+ .../server/container_update_resources_unix.go |  6 ++--
+ 5 files changed, 24 insertions(+), 17 deletions(-)
+
+diff --git a/vendor/github.com/containerd/cri/pkg/config/config.go b/vendor/github.com/containerd/cri/pkg/config/config.go
+index 9c8d2e30..417b3fb3 100644
+--- a/vendor/github.com/containerd/cri/pkg/config/config.go
++++ b/vendor/github.com/containerd/cri/pkg/config/config.go
+@@ -236,6 +236,10 @@ type PluginConfig struct {
+ 	// container requests with huge page limits if the cgroup controller for hugepages is not present.
+ 	// This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
+ 	TolerateMissingHugePagesCgroupController bool `toml:"tolerate_missing_hugepages_controller" json:"tolerateMissingHugePagesCgroupController"`
++	// DisableHugePagesCgroupController indicates to disable the hugetlb controller even when it is
++	// present in /sys/fs/cgroup/cgroup.controllers.
++	// This helps with running rootless mode + cgroup v2 + systemd but without hugetlb delegation.
++	DisableHugePagesCgroupController bool `toml:"disable_hugepages_cgroup_controller" json:"disableHugePagesCgroupController"`
+ 	// IgnoreImageDefinedVolumes ignores volumes defined by the image. Useful for better resource
+ 	// isolation, security and early detection of issues in the mount configuration when using
+ 	// ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+diff --git a/vendor/github.com/containerd/cri/pkg/config/config_unix.go b/vendor/github.com/containerd/cri/pkg/config/config_unix.go
+index ce441c61..ec2125db 100644
+--- a/vendor/github.com/containerd/cri/pkg/config/config_unix.go
++++ b/vendor/github.com/containerd/cri/pkg/config/config_unix.go
+@@ -66,6 +66,7 @@ func DefaultConfig() PluginConfig {
+ 		MaxConcurrentDownloads:                   3,
+ 		DisableProcMount:                         false,
+ 		TolerateMissingHugePagesCgroupController: true,
++		DisableHugePagesCgroupController:         false,
+ 		IgnoreImageDefinedVolumes:                false,
+ 	}
+ }
+diff --git a/vendor/github.com/containerd/cri/pkg/containerd/opts/spec_unix.go b/vendor/github.com/containerd/cri/pkg/containerd/opts/spec_unix.go
+index d72d8156..7ced77f3 100644
+--- a/vendor/github.com/containerd/cri/pkg/containerd/opts/spec_unix.go
++++ b/vendor/github.com/containerd/cri/pkg/containerd/opts/spec_unix.go
+@@ -408,7 +408,7 @@ func WithSelinuxLabels(process, mount string) oci.SpecOpts {
+ }
+ 
+ // WithResources sets the provided resource restrictions
+-func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHugePagesCgroupController bool) oci.SpecOpts {
++func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHugePagesCgroupController, disableHugePages bool) oci.SpecOpts {
+ 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {
+ 		if resources == nil {
+ 			return nil
+@@ -451,19 +451,21 @@ func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHu
+ 		if limit != 0 {
+ 			s.Linux.Resources.Memory.Limit = &limit
+ 		}
+-		if isHugePagesControllerPresent() {
+-			for _, limit := range hugepages {
+-				s.Linux.Resources.HugepageLimits = append(s.Linux.Resources.HugepageLimits, runtimespec.LinuxHugepageLimit{
+-					Pagesize: limit.PageSize,
+-					Limit:    limit.Limit,
+-				})
+-			}
+-		} else {
+-			if !tolerateMissingHugePagesCgroupController {
+-				return errors.Errorf("huge pages limits are specified but hugetlb cgroup controller is missing. " +
+-					"Please set tolerate_missing_hugepages_controller to `true` to ignore this error")
++		if !disableHugePages {
++			if isHugePagesControllerPresent() {
++				for _, limit := range hugepages {
++					s.Linux.Resources.HugepageLimits = append(s.Linux.Resources.HugepageLimits, runtimespec.LinuxHugepageLimit{
++						Pagesize: limit.PageSize,
++						Limit:    limit.Limit,
++					})
++				}
++			} else {
++				if !tolerateMissingHugePagesCgroupController {
++					return errors.Errorf("huge pages limits are specified but hugetlb cgroup controller is missing. " +
++						"Please set tolerate_missing_hugepages_controller to `true` to ignore this error")
++				}
++				logrus.Warn("hugetlb cgroup controller is absent. skipping huge pages limits")
+ 			}
+-			logrus.Warn("hugetlb cgroup controller is absent. skipping huge pages limits")
+ 		}
+ 		return nil
+ 	}
+diff --git a/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go b/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
+index 99f4183c..50484374 100644
+--- a/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
++++ b/vendor/github.com/containerd/cri/pkg/server/container_create_unix.go
+@@ -225,7 +225,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
+ 	if c.config.DisableCgroup {
+ 		specOpts = append(specOpts, customopts.WithDisabledCgroups)
+ 	} else {
+-		specOpts = append(specOpts, customopts.WithResources(config.GetLinux().GetResources(), c.config.TolerateMissingHugePagesCgroupController))
++		specOpts = append(specOpts, customopts.WithResources(config.GetLinux().GetResources(), c.config.TolerateMissingHugePagesCgroupController, c.config.DisableHugePagesCgroupController))
+ 		if sandboxConfig.GetLinux().GetCgroupParent() != "" {
+ 			cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id)
+ 			specOpts = append(specOpts, oci.WithCgroup(cgroupsPath))
+diff --git a/vendor/github.com/containerd/cri/pkg/server/container_update_resources_unix.go b/vendor/github.com/containerd/cri/pkg/server/container_update_resources_unix.go
+index 5fa63d50..152d9692 100644
+--- a/vendor/github.com/containerd/cri/pkg/server/container_update_resources_unix.go
++++ b/vendor/github.com/containerd/cri/pkg/server/container_update_resources_unix.go
+@@ -73,7 +73,7 @@ func (c *criService) updateContainerResources(ctx context.Context,
+ 		return errors.Wrap(err, "failed to get container spec")
+ 	}
+ 	newSpec, err := updateOCILinuxResource(ctx, oldSpec, resources,
+-		c.config.TolerateMissingHugePagesCgroupController)
++		c.config.TolerateMissingHugePagesCgroupController, c.config.DisableHugePagesCgroupController)
+ 	if err != nil {
+ 		return errors.Wrap(err, "failed to update resource in spec")
+ 	}
+@@ -134,7 +134,7 @@ func updateContainerSpec(ctx context.Context, cntr containerd.Container, spec *r
+ 
+ // updateOCILinuxResource updates container resource limit.
+ func updateOCILinuxResource(ctx context.Context, spec *runtimespec.Spec, new *runtime.LinuxContainerResources,
+-	tolerateMissingHugePagesCgroupController bool) (*runtimespec.Spec, error) {
++	tolerateMissingHugePagesCgroupController, disableHugePages bool) (*runtimespec.Spec, error) {
+ 	// Copy to make sure old spec is not changed.
+ 	var cloned runtimespec.Spec
+ 	if err := util.DeepCopy(&cloned, spec); err != nil {
+@@ -143,7 +143,7 @@ func updateOCILinuxResource(ctx context.Context, spec *runtimespec.Spec, new *ru
+ 	if cloned.Linux == nil {
+ 		cloned.Linux = &runtimespec.Linux{}
+ 	}
+-	if err := opts.WithResources(new, tolerateMissingHugePagesCgroupController)(ctx, nil, nil, &cloned); err != nil {
++	if err := opts.WithResources(new, tolerateMissingHugePagesCgroupController, disableHugePages)(ctx, nil, nil, &cloned); err != nil {
+ 		return nil, errors.Wrap(err, "unable to set linux container resources")
+ 	}
+ 	return &cloned, nil
+-- 
+2.25.1
+

--- a/src/patches/kubernetes/0001-kubelet-cm-ignore-sysctl-error-when-running-in-usern.patch
+++ b/src/patches/kubernetes/0001-kubelet-cm-ignore-sysctl-error-when-running-in-usern.patch
@@ -1,7 +1,7 @@
 From 4e02c9415857d0083b058b029b34bb298ec9883a Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Tue, 21 Aug 2018 16:45:04 +0900
-Subject: [PATCH 1/3] kubelet/cm: ignore sysctl error when running in userns
+Subject: [PATCH 1/4] kubelet/cm: ignore sysctl error when running in userns
 
 Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 ---

--- a/src/patches/kubernetes/0002-kube-proxy-allow-running-in-userns.patch
+++ b/src/patches/kubernetes/0002-kube-proxy-allow-running-in-userns.patch
@@ -1,7 +1,7 @@
 From c63656823402b1fab811a3dc86311332d11582d7 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Thu, 23 Aug 2018 14:14:44 +0900
-Subject: [PATCH 2/3] kube-proxy: allow running in userns
+Subject: [PATCH 2/4] kube-proxy: allow running in userns
 
 Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 ---

--- a/src/patches/kubernetes/0003-kubelet-new-feature-gate-SupportNoneCgroupDriver.patch
+++ b/src/patches/kubernetes/0003-kubelet-new-feature-gate-SupportNoneCgroupDriver.patch
@@ -1,7 +1,7 @@
 From b48434350157e3bd319d2f651654d1db3ce568a9 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Sun, 2 Jun 2019 18:39:05 +0900
-Subject: [PATCH 3/3] kubelet: new feature gate: SupportNoneCgroupDriver
+Subject: [PATCH 3/4] kubelet: new feature gate: SupportNoneCgroupDriver
 
 The "none" driver is expected to be used in "rootless" mode until OCI/CRI runtime
 get support for cgroup2 (unified) mode with nsdelegate.

--- a/src/patches/kubernetes/0004-kubelet-new-feature-gate-Rootless.patch
+++ b/src/patches/kubernetes/0004-kubelet-new-feature-gate-Rootless.patch
@@ -1,0 +1,393 @@
+From a95d960e48e419ec5d0a80926b4080b879077863 Mon Sep 17 00:00:00 2001
+From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+Date: Mon, 29 Jun 2020 15:10:05 +0900
+Subject: [PATCH 4/4] kubelet: new feature gate: Rootless
+
+The Rootless feature gate allows the systemd cgroup manager (v2) to use the user instance of systemd.
+A container is executed in a cgroup like "/user.slice/user-1001.slice/user@1001.service/user.slice/cri-containerd-6938564e754ad86269a536ed19172af0eff5f7ff0a41eefc5b433a76f1f38f16.scope".
+
+* Tested with containerd and crun.
+* Requires the kubelet and the CRI runtime to be executed in USER+MNT+NET namespaces, mostly via RootlessKit.
+* cgroupsPerQOS is currently unsupported.
+
+Example kubelet config:
+```yaml
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+...
+featureGates:
+  Rootless: true
+rootless: true
+cgroupDriver: systemd
+cgroupsPerQOS: false
+```
+
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
+---
+ cmd/kubelet/app/server.go                     |  1 +
+ pkg/features/kube_features.go                 |  7 +++
+ pkg/kubelet/apis/config/fuzzer/fuzzer.go      |  1 +
+ pkg/kubelet/apis/config/helpers_test.go       |  1 +
+ pkg/kubelet/apis/config/types.go              |  4 ++
+ .../config/v1beta1/zz_generated.conversion.go |  2 +
+ pkg/kubelet/cm/cgroup_manager_linux.go        | 47 ++++++++++++-------
+ pkg/kubelet/cm/container_manager.go           |  1 +
+ pkg/kubelet/cm/container_manager_linux.go     | 17 ++++++-
+ pkg/kubelet/cm/pod_container_manager_linux.go |  7 ++-
+ .../cm/pod_container_manager_linux_test.go    |  2 +-
+ .../k8s.io/kubelet/config/v1beta1/types.go    |  6 +++
+ test/e2e_node/node_container_manager_test.go  |  2 +-
+ 13 files changed, 76 insertions(+), 22 deletions(-)
+
+diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
+index 55e15c533d7..3492709f5c6 100644
+--- a/cmd/kubelet/app/server.go
++++ b/cmd/kubelet/app/server.go
+@@ -733,6 +733,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate f
+ 				EnforceCPULimits:                      s.CPUCFSQuota,
+ 				CPUCFSQuotaPeriod:                     s.CPUCFSQuotaPeriod.Duration,
+ 				ExperimentalTopologyManagerPolicy:     s.TopologyManagerPolicy,
++				Rootless:                              s.Rootless,
+ 			},
+ 			s.FailSwapOn,
+ 			devicePluginEnabled,
+diff --git a/pkg/features/kube_features.go b/pkg/features/kube_features.go
+index 0a14541b08d..7eb82956055 100644
+--- a/pkg/features/kube_features.go
++++ b/pkg/features/kube_features.go
+@@ -602,6 +602,12 @@ const (
+ 	// have FQDN, this feature has no effect.
+ 	SetHostnameAsFQDN featuregate.Feature = "SetHostnameAsFQDN"
+ 
++	// owner: @AkihiroSuda
++	// alpha: v1.XX
++	//
++	// Enable rootless mode.
++	Rootless featuregate.Feature = "Rootless"
++
+ 	// owner: @AkihiroSuda
+ 	// alpha: v1.XX
+ 	//
+@@ -705,6 +711,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
+ 	AnyVolumeDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
+ 	DefaultPodTopologySpread:                       {Default: false, PreRelease: featuregate.Alpha},
+ 	SetHostnameAsFQDN:                              {Default: false, PreRelease: featuregate.Alpha},
++	Rootless:                                       {Default: false, PreRelease: featuregate.Alpha},
+ 	SupportNoneCgroupDriver:                        {Default: false, PreRelease: featuregate.Alpha},
+ 
+ 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
+diff --git a/pkg/kubelet/apis/config/fuzzer/fuzzer.go b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+index 06c636be2ad..c38cb1bdc9d 100644
+--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
++++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+@@ -60,6 +60,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
+ 			obj.ImageGCHighThresholdPercent = 85
+ 			obj.ImageGCLowThresholdPercent = 80
+ 			obj.KernelMemcgNotification = false
++			obj.Rootless = false
+ 			obj.MaxOpenFiles = 1000000
+ 			obj.MaxPods = 110
+ 			obj.PodPidsLimit = -1
+diff --git a/pkg/kubelet/apis/config/helpers_test.go b/pkg/kubelet/apis/config/helpers_test.go
+index e8b4581589f..4ff5781f055 100644
+--- a/pkg/kubelet/apis/config/helpers_test.go
++++ b/pkg/kubelet/apis/config/helpers_test.go
+@@ -217,6 +217,7 @@ var (
+ 		"RegistryBurst",
+ 		"RegistryPullQPS",
+ 		"ReservedSystemCPUs",
++		"Rootless",
+ 		"RuntimeRequestTimeout.Duration",
+ 		"RunOnce",
+ 		"SerializeImagePulls",
+diff --git a/pkg/kubelet/apis/config/types.go b/pkg/kubelet/apis/config/types.go
+index d6a7f07c8b5..031f34ef510 100644
+--- a/pkg/kubelet/apis/config/types.go
++++ b/pkg/kubelet/apis/config/types.go
+@@ -324,6 +324,10 @@ type KubeletConfiguration struct {
+ 	// kernelMemcgNotification if enabled, the kubelet will integrate with the kernel memcg
+ 	// notification to determine if memory eviction thresholds are crossed rather than polling.
+ 	KernelMemcgNotification bool
++	// Rootless enables the rootless cgroup manager.
++	// Requires cgroup v2 and systemd.
++	// Requires the Rootless feature gate to be enabled.
++	Rootless bool
+ 
+ 	/* the following fields are meant for Node Allocatable */
+ 
+diff --git a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+index 8efd41941c1..07876d4561b 100644
+--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
++++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+@@ -331,6 +331,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in
+ 		return err
+ 	}
+ 	out.ConfigMapAndSecretChangeDetectionStrategy = config.ResourceChangeDetectionStrategy(in.ConfigMapAndSecretChangeDetectionStrategy)
++	out.Rootless = in.Rootless
+ 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
+ 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
+ 	out.ReservedSystemCPUs = in.ReservedSystemCPUs
+@@ -479,6 +480,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in
+ 	out.ConfigMapAndSecretChangeDetectionStrategy = v1beta1.ResourceChangeDetectionStrategy(in.ConfigMapAndSecretChangeDetectionStrategy)
+ 	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
+ 	out.KernelMemcgNotification = in.KernelMemcgNotification
++	out.Rootless = in.Rootless
+ 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
+ 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
+ 	out.SystemReservedCgroup = in.SystemReservedCgroup
+diff --git a/pkg/kubelet/cm/cgroup_manager_linux.go b/pkg/kubelet/cm/cgroup_manager_linux.go
+index be33ee358c4..c81c47d772c 100644
+--- a/pkg/kubelet/cm/cgroup_manager_linux.go
++++ b/pkg/kubelet/cm/cgroup_manager_linux.go
+@@ -136,18 +136,22 @@ func IsSystemdStyleName(name string) bool {
+ type libcontainerAdapter struct {
+ 	// cgroupManagerType defines how to interface with libcontainer
+ 	cgroupManagerType libcontainerCgroupManagerType
++	rootless          bool
+ }
+ 
+ // newLibcontainerAdapter returns a configured libcontainerAdapter for specified manager.
+ // it does any initialization required by that manager to function.
+-func newLibcontainerAdapter(cgroupManagerType libcontainerCgroupManagerType) *libcontainerAdapter {
+-	return &libcontainerAdapter{cgroupManagerType: cgroupManagerType}
++func newLibcontainerAdapter(cgroupManagerType libcontainerCgroupManagerType, rootless bool) *libcontainerAdapter {
++	return &libcontainerAdapter{cgroupManagerType: cgroupManagerType, rootless: rootless}
+ }
+ 
+ // newManager returns an implementation of cgroups.Manager
+ func (l *libcontainerAdapter) newManager(cgroups *libcontainerconfigs.Cgroup, paths map[string]string) (libcontainercgroups.Manager, error) {
+ 	switch l.cgroupManagerType {
+ 	case libcontainerCgroupfs:
++		if l.rootless {
++			return nil, fmt.Errorf("cgroup manager %v does not support rootless", l.cgroupManagerType)
++		}
+ 		if libcontainercgroups.IsCgroup2UnifiedMode() {
+ 			return cgroupfs2.NewManager(cgroups, paths["memory"], false)
+ 		}
+@@ -158,7 +162,10 @@ func (l *libcontainerAdapter) newManager(cgroups *libcontainerconfigs.Cgroup, pa
+ 			panic("systemd cgroup manager not available")
+ 		}
+ 		if libcontainercgroups.IsCgroup2UnifiedMode() {
+-			return cgroupsystemd.NewUnifiedManager(cgroups, paths["memory"], false), nil
++			return cgroupsystemd.NewUnifiedManager(cgroups, paths["memory"], l.rootless), nil
++		}
++		if l.rootless {
++			return nil, fmt.Errorf("cgroup manager %v requires cgroup v2 for rootless", l.cgroupManagerType)
+ 		}
+ 		return cgroupsystemd.NewLegacyManager(cgroups, paths), nil
+ 	}
+@@ -192,7 +199,7 @@ type cgroupManagerImpl struct {
+ var _ CgroupManager = &cgroupManagerImpl{}
+ 
+ // NewCgroupManager is a factory method that returns a CgroupManager
+-func NewCgroupManager(cs *CgroupSubsystems, cgroupDriver string) (CgroupManager, error) {
++func NewCgroupManager(cs *CgroupSubsystems, cgroupDriver string, rootless bool) (CgroupManager, error) {
+ 	if cgroupDriver == noneDriver {
+ 		if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.SupportNoneCgroupDriver) {
+ 			return nil, fmt.Errorf("cgroup driver %q requires SupportNoneCgroupDriver feature gate", cgroupDriver)
+@@ -205,9 +212,12 @@ func NewCgroupManager(cs *CgroupSubsystems, cgroupDriver string) (CgroupManager,
+ 	if cgroupDriver == string(libcontainerSystemd) {
+ 		managerType = libcontainerSystemd
+ 	}
++	if rootless && !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.Rootless) {
++		return nil, fmt.Errorf("rootless requires Rootless feature gate")
++	}
+ 	return &cgroupManagerImpl{
+ 		subsystems: cs,
+-		adapter:    newLibcontainerAdapter(managerType),
++		adapter:    newLibcontainerAdapter(managerType, rootless),
+ 	}, nil
+ }
+ 
+@@ -493,21 +503,23 @@ func propagateControllers(path string) error {
+ }
+ 
+ // setResourcesV2 sets cgroup resource limits on cgroup v2
+-func setResourcesV2(cgroupConfig *libcontainerconfigs.Cgroup) error {
++func setResourcesV2(cgroupConfig *libcontainerconfigs.Cgroup, rootless bool) error {
+ 	if err := propagateControllers(cgroupConfig.Path); err != nil {
+ 		return err
+ 	}
+-	cgroupConfig.Resources.Devices = []*libcontainerconfigs.DeviceRule{
+-		{
+-			Type:        'a',
+-			Permissions: "rwm",
+-			Allow:       true,
+-			Minor:       libcontainerconfigs.Wildcard,
+-			Major:       libcontainerconfigs.Wildcard,
+-		},
++	if !rootless {
++		cgroupConfig.Resources.Devices = []*libcontainerconfigs.DeviceRule{
++			{
++				Type:        'a',
++				Permissions: "rwm",
++				Allow:       true,
++				Minor:       libcontainerconfigs.Wildcard,
++				Major:       libcontainerconfigs.Wildcard,
++			},
++		}
+ 	}
+ 
+-	manager, err := cgroupfs2.NewManager(cgroupConfig, cgroupConfig.Path, false)
++	manager, err := cgroupfs2.NewManager(cgroupConfig, cgroupConfig.Path, rootless)
+ 	if err != nil {
+ 		return fmt.Errorf("failed to create cgroup v2 manager: %v", err)
+ 	}
+@@ -614,7 +626,8 @@ func (m *cgroupManagerImpl) Update(cgroupConfig *CgroupConfig) error {
+ 	}
+ 
+ 	if unified {
+-		if err := setResourcesV2(libcontainerCgroupConfig); err != nil {
++		rootless := m.adapter.rootless
++		if err := setResourcesV2(libcontainerCgroupConfig, rootless); err != nil {
+ 			return fmt.Errorf("failed to set resources for cgroup %v: %v", cgroupConfig.Name, err)
+ 		}
+ 	} else {
+@@ -774,7 +787,7 @@ func (m *cgroupManagerImpl) GetResourceStats(name CgroupName) (*ResourceStats, e
+ 	var stats *libcontainercgroups.Stats
+ 	if libcontainercgroups.IsCgroup2UnifiedMode() {
+ 		cgroupPath := m.buildCgroupUnifiedPath(name)
+-		manager, err := cgroupfs2.NewManager(nil, cgroupPath, false)
++		manager, err := cgroupfs2.NewManager(nil, cgroupPath, m.adapter.rootless)
+ 		if err != nil {
+ 			return nil, fmt.Errorf("failed to create cgroup v2 manager: %v", err)
+ 		}
+diff --git a/pkg/kubelet/cm/container_manager.go b/pkg/kubelet/cm/container_manager.go
+index a9cb41cbcfe..7a6a70741cd 100644
+--- a/pkg/kubelet/cm/container_manager.go
++++ b/pkg/kubelet/cm/container_manager.go
+@@ -135,6 +135,7 @@ type NodeConfig struct {
+ 	EnforceCPULimits                      bool
+ 	CPUCFSQuotaPeriod                     time.Duration
+ 	ExperimentalTopologyManagerPolicy     string
++	Rootless                              bool
+ }
+ 
+ type NodeAllocatableConfig struct {
+diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
+index d165aa5ceed..fe27f7c37d1 100644
+--- a/pkg/kubelet/cm/container_manager_linux.go
++++ b/pkg/kubelet/cm/container_manager_linux.go
+@@ -259,7 +259,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
+ 
+ 	// Turn CgroupRoot from a string (in cgroupfs path format) to internal CgroupName
+ 	cgroupRoot := ParseCgroupfsToCgroupName(nodeConfig.CgroupRoot)
+-	cgroupManager, err := NewCgroupManager(subsystems, nodeConfig.CgroupDriver)
++	cgroupManager, err := NewCgroupManager(subsystems, nodeConfig.CgroupDriver, nodeConfig.Rootless)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -268,6 +268,12 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
+ 		if nodeConfig.CgroupDriver == noneDriver {
+ 			return nil, fmt.Errorf("invalid configuration: cgroups-per-qos is not supported for %s cgroup driver", nodeConfig.CgroupDriver)
+ 		}
++
++		if nodeConfig.Rootless {
++			// TODO(AkihiroSuda): support rootless
++			return nil, fmt.Errorf("invalid configuration: cgroups-per-qos is not supported for rootless")
++		}
++
+ 		// this does default to / when enabled, but this tests against regressions.
+ 		if nodeConfig.CgroupRoot == "" {
+ 			return nil, fmt.Errorf("invalid configuration: cgroups-per-qos was specified and cgroup-root was not specified. To enable the QoS cgroup hierarchy you need to specify a valid cgroup-root")
+@@ -368,7 +374,8 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
+ 		}
+ 	}
+ 	return &podContainerManagerNoop{
+-		cgroupRoot: cm.cgroupRoot,
++		cgroupRoot:      cm.cgroupRoot,
++		rootlessSystemd: cm.NodeConfig.Rootless && cm.NodeConfig.CgroupDriver == "systemd",
+ 	}
+ }
+ 
+@@ -510,6 +517,9 @@ func (cm *containerManagerImpl) setupNode(activePods ActivePodsFunc) error {
+ 		if cm.SystemCgroupsName == "/" {
+ 			return fmt.Errorf("system container cannot be root (\"/\")")
+ 		}
++		if cm.Rootless {
++			return fmt.Errorf("rootless does not support SystemCgroupsName")
++		}
+ 		cont, err := newSystemCgroups(cm.SystemCgroupsName)
+ 		if err != nil {
+ 			return err
+@@ -521,6 +531,9 @@ func (cm *containerManagerImpl) setupNode(activePods ActivePodsFunc) error {
+ 	}
+ 
+ 	if cm.KubeletCgroupsName != "" {
++		if cm.Rootless {
++			return fmt.Errorf("rootless does not support KubeletCgroupsName")
++		}
+ 		cont, err := newSystemCgroups(cm.KubeletCgroupsName)
+ 		if err != nil {
+ 			return err
+diff --git a/pkg/kubelet/cm/pod_container_manager_linux.go b/pkg/kubelet/cm/pod_container_manager_linux.go
+index ef3499f44fc..f05da3f5035 100644
+--- a/pkg/kubelet/cm/pod_container_manager_linux.go
++++ b/pkg/kubelet/cm/pod_container_manager_linux.go
+@@ -293,7 +293,8 @@ func (m *podContainerManagerImpl) GetAllPodsFromCgroups() (map[types.UID]CgroupN
+ // enabled, so Exists() returns true always as the cgroupRoot
+ // is expected to always exist.
+ type podContainerManagerNoop struct {
+-	cgroupRoot CgroupName
++	cgroupRoot      CgroupName
++	rootlessSystemd bool
+ }
+ 
+ // Make sure that podContainerManagerStub implements the PodContainerManager interface
+@@ -308,6 +309,10 @@ func (m *podContainerManagerNoop) EnsureExists(_ *v1.Pod) error {
+ }
+ 
+ func (m *podContainerManagerNoop) GetPodContainerName(_ *v1.Pod) (CgroupName, string) {
++	if m.rootlessSystemd {
++		// "user.slice" is set to PodConfig.Linux.CgroupParent
++		return m.cgroupRoot, "user.slice"
++	}
+ 	return m.cgroupRoot, ""
+ }
+ 
+diff --git a/pkg/kubelet/cm/pod_container_manager_linux_test.go b/pkg/kubelet/cm/pod_container_manager_linux_test.go
+index fda4177a05b..db4ed280da1 100644
+--- a/pkg/kubelet/cm/pod_container_manager_linux_test.go
++++ b/pkg/kubelet/cm/pod_container_manager_linux_test.go
+@@ -100,7 +100,7 @@ func TestIsCgroupPod(t *testing.T) {
+ 		},
+ 	}
+ 	for _, cgroupDriver := range []string{"cgroupfs", "systemd"} {
+-		cm, err := NewCgroupManager(nil, cgroupDriver)
++		cm, err := NewCgroupManager(nil, cgroupDriver, false)
+ 		if err != nil {
+ 			t.Fatal(err)
+ 		}
+diff --git a/staging/src/k8s.io/kubelet/config/v1beta1/types.go b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+index 144c1d371dd..19b5a86bc1e 100644
+--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
++++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+@@ -702,6 +702,12 @@ type KubeletConfiguration struct {
+ 	// Default: "Watch"
+ 	// +optional
+ 	ConfigMapAndSecretChangeDetectionStrategy ResourceChangeDetectionStrategy `json:"configMapAndSecretChangeDetectionStrategy,omitempty"`
++	// Rootless enables the rootless cgroup manager.
++	// Requires cgroup v2 and systemd.
++	// Requires the Rootless feature gate to be enabled.
++	// Default: false
++	// +optional
++	Rootless bool `json:"rootless,omitempty"`
+ 
+ 	/* the following fields are meant for Node Allocatable */
+ 
+diff --git a/test/e2e_node/node_container_manager_test.go b/test/e2e_node/node_container_manager_test.go
+index b1307c13213..49d775881f0 100644
+--- a/test/e2e_node/node_container_manager_test.go
++++ b/test/e2e_node/node_container_manager_test.go
+@@ -167,7 +167,7 @@ func runTest(f *framework.Framework) error {
+ 	}
+ 
+ 	// Create a cgroup manager object for manipulating cgroups.
+-	cgroupManager, err := cm.NewCgroupManager(subsystems, oldCfg.CgroupDriver)
++	cgroupManager, err := cm.NewCgroupManager(subsystems, oldCfg.CgroupDriver, false)
+ 	if err != nil {
+ 		return nil
+ 	}
+-- 
+2.25.1
+

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,7 +13,7 @@ set -u
 set +e
 set -x
 systemctl --user -T -f stop u7s.target
-systemctl --user -T -f stop 'u7s-*'
+systemctl --user -T -f stop --signal=KILL 'u7s-*'
 systemctl --user -T disable u7s.target
 rm -rf ${config_dir}/systemd/user/u7s*
 systemctl --user -T daemon-reload


### PR DESCRIPTION
Now resource limitation works. A container is executed in a cgroup like `/user.slice/user-1001.slice/user@1001.service/user.slice/cri-containerd-6938564e754ad86269a536ed19172af0eff5f7ff0a41eefc5b433a76f1f38f16.scope`. `cgroupsPerQOS` is currently unsupported.

Usage: `install.sh --cri=containerd --cgroup-manager=systemd`