### PR TITLE
reduce the amount of the patches

### DIFF
--- a/boot/kube-proxy.sh
+++ b/boot/kube-proxy.sh
@@ -12,6 +12,13 @@ clientConnection:
 featureGates:
 # EndpointSliceProxying seems to break ClusterIP: https://github.com/rootless-containers/usernetes/pull/179
   EndpointSliceProxying: false
+conntrack:
+# Skip setting sysctl value "net.netfilter.nf_conntrack_max"
+  maxPerCore: 0
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
+  tcpEstablishedTimeout: 0s
+# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
+  tcpCloseWaitTimeout: 0s
 EOF
 
 exec $(dirname $0)/nsenter.sh kube-proxy \

--- a/src/patches/kubernetes/0001-kubelet-cm-ignore-sysctl-error-when-running-in-usern.patch
+++ b/src/patches/kubernetes/0001-kubelet-cm-ignore-sysctl-error-when-running-in-usern.patch
@@ -1,4 +1,4 @@
-From ec2446d60464c9452b701e867130fc7fe58ab057 Mon Sep 17 00:00:00 2001
+From 5b4785d2cab960af9a8aeacfd474186c377d8df1 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Tue, 21 Aug 2018 16:45:04 +0900
 Subject: [PATCH 1/3] kubelet/cm: ignore sysctl error when running in userns

--- a/src/patches/kubernetes/0002-kube-proxy-allow-running-in-userns.patch
+++ b/src/patches/kubernetes/0002-kube-proxy-allow-running-in-userns.patch
@@ -1,56 +1,15 @@
-From 246b6db18bb9f74e55c279855eebe520b4e01f14 Mon Sep 17 00:00:00 2001
+From 684fe7c77aa97daec1a1109667ba06742b75c8d9 Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Thu, 23 Aug 2018 14:14:44 +0900
 Subject: [PATCH 2/3] kube-proxy: allow running in userns
 
-Ignore errors during setting the following sysctl values,
-by setting connTracker to nil:
-- net.netfilter.nf_conntrack_max
-- net.netfilter.nf_conntrack_tcp_timeout_established
-- net.netfilter.nf_conntrack_tcp_timeout_close_wait
-
-Also ignore an error during setting RLIMIT_NOFILE.
+Ignore an error during setting RLIMIT_NOFILE.
 
 Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 ---
- cmd/kube-proxy/app/server_others.go | 9 ++++++++-
- pkg/proxy/userspace/proxier.go      | 6 +++++-
- 2 files changed, 13 insertions(+), 2 deletions(-)
+ pkg/proxy/userspace/proxier.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
-diff --git a/cmd/kube-proxy/app/server_others.go b/cmd/kube-proxy/app/server_others.go
-index bcbf7392f06..13ee146fb0b 100644
---- a/cmd/kube-proxy/app/server_others.go
-+++ b/cmd/kube-proxy/app/server_others.go
-@@ -35,6 +35,7 @@ import (
- 
- 	"k8s.io/apimachinery/pkg/fields"
- 
-+	libcontainersystem "github.com/opencontainers/runc/libcontainer/system"
- 	v1 "k8s.io/api/core/v1"
- 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
- 	"k8s.io/apimachinery/pkg/types"
-@@ -361,6 +362,12 @@ func newProxyServer(
- 		}
- 	}
- 
-+	var connTracker Conntracker
-+	if !libcontainersystem.RunningInUserNS() {
-+		// if we are in userns, sysctl does not work and connTracker should be kept nil
-+		connTracker = &realConntracker{}
-+	}
-+
- 	return &ProxyServer{
- 		Client:                 client,
- 		EventClient:            eventClient,
-@@ -372,7 +379,7 @@ func newProxyServer(
- 		Broadcaster:            eventBroadcaster,
- 		Recorder:               recorder,
- 		ConntrackConfiguration: config.Conntrack,
--		Conntracker:            &realConntracker{},
-+		Conntracker:            connTracker,
- 		ProxyMode:              proxyMode,
- 		NodeRef:                nodeRef,
- 		MetricsBindAddress:     config.MetricsBindAddress,
 diff --git a/pkg/proxy/userspace/proxier.go b/pkg/proxy/userspace/proxier.go
 index 32bd5e56684..503818954ec 100644
 --- a/pkg/proxy/userspace/proxier.go

--- a/src/patches/kubernetes/0003-Not-for-Upstream-kubelet-new-cgroup-driver-none.patch
+++ b/src/patches/kubernetes/0003-Not-for-Upstream-kubelet-new-cgroup-driver-none.patch
@@ -1,4 +1,4 @@
-From e29c0c4b0117d1b1f90838610725a77a347589ac Mon Sep 17 00:00:00 2001
+From 2e41845075bd239ab993c234d12e865fcb48db4f Mon Sep 17 00:00:00 2001
 From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Sun, 2 Jun 2019 18:39:05 +0900
 Subject: [PATCH 3/3] [Not for Upstream] kubelet: new cgroup driver: "none"
@@ -17,10 +17,10 @@ Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
  4 files changed, 88 insertions(+), 20 deletions(-)
 
 diff --git a/cmd/kubelet/app/options/options.go b/cmd/kubelet/app/options/options.go
-index e72ce8bb0fe..fcfaea2f67a 100644
+index 9774f5ee823..74de80e3fdd 100644
 --- a/cmd/kubelet/app/options/options.go
 +++ b/cmd/kubelet/app/options/options.go
-@@ -489,7 +489,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
+@@ -483,7 +483,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
  	fs.StringVar(&c.ProviderID, "provider-id", c.ProviderID, "Unique identifier for identifying the node in a machine database, i.e cloudprovider")
  
  	fs.BoolVar(&c.CgroupsPerQOS, "cgroups-per-qos", c.CgroupsPerQOS, "Enable creation of QoS cgroup hierarchy, if true top level QoS and pod cgroups are created.")
@@ -30,7 +30,7 @@ index e72ce8bb0fe..fcfaea2f67a 100644
  	fs.StringVar(&c.CPUManagerPolicy, "cpu-manager-policy", c.CPUManagerPolicy, "CPU Manager policy to use. Possible values: 'none', 'static'. Default: 'none'")
  	fs.DurationVar(&c.CPUManagerReconcilePeriod.Duration, "cpu-manager-reconcile-period", c.CPUManagerReconcilePeriod.Duration, "<Warning: Alpha feature> CPU Manager reconciliation period. Examples: '10s', or '1m'. If not supplied, defaults to 'NodeStatusUpdateFrequency'")
 diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
-index 6a60dc3206d..7af16937189 100644
+index 499e47f7b08..37faf70c5aa 100644
 --- a/cmd/kubelet/app/server.go
 +++ b/cmd/kubelet/app/server.go
 @@ -607,26 +607,30 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend


### PR DESCRIPTION
`kube-proxy` turned out to be runnable without patching connTracker,
when the following KubeletConfiguration is specified:

```
conntrack:
# Skip setting sysctl value "net.netfilter.nf_conntrack_max"
  maxPerCore: 0
# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_established"
  tcpEstablishedTimeout: 0s
# Skip setting "net.netfilter.nf_conntrack_tcp_timeout_close"
  tcpCloseWaitTimeout: 0s
```
