### PR TITLE
improv: Use PrivateMounts for rootlesskit service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,7 @@ PartOf=u7s.target
 [Service]
 ExecStart=${base}/boot/rootlesskit.sh ${base}/boot/${cri}.sh
 Delegate=yes
+PrivateMounts=true
 ${service_common}
 EOF
 else


### PR DESCRIPTION
This change allows rootlesskit to run slirp4netns with its sandbox
enabled even when running as root. Without this change, when running as
root, slirp will fail to `pivot_root()` into its `/tmp` directory since
the current mount namespace isn't private.