### PR TITLE
improve 'hostname' compatibility

### DIFF
--- a/boot/rootlesskit.sh
+++ b/boot/rootlesskit.sh
@@ -16,7 +16,11 @@ rk_state_dir=$XDG_RUNTIME_DIR/usernetes/rootlesskit
 : ${_U7S_CHILD=0}
 if [[ $_U7S_CHILD == 0 ]]; then
 	_U7S_CHILD=1
-	: ${U7S_PARENT_IP=$(hostname -I | sed -e 's/ .*//g')}
+	if hostname -I &>/dev/null ; then
+		: ${U7S_PARENT_IP=$(hostname -I | sed -e 's/ .*//g')}
+	else
+		: ${U7S_PARENT_IP=$(hostname -i | sed -e 's/ .*//g')}
+	fi
 	export _U7S_CHILD U7S_PARENT_IP
 
 	# Re-exec the script via RootlessKit, so as to create unprivileged {user,mount,network} namespaces.

--- a/common/cfssl.sh
+++ b/common/cfssl.sh
@@ -140,7 +140,11 @@ if [[ -f "${master_d}/kubernetes.pem" ]]; then
 else
 	log::info "Creating ${master_d}/{kubernetes.pem,kubernetes-key.pem}"
 	k_hostnames="kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.svc.cluster.local"
-	ip_addrs=$(hostname -I | sed -e 's/ /,/g' -e 's/,$//g')
+	if hostname -I &>/dev/null ; then
+		ip_addrs=$(hostname -I | sed -e 's/ /,/g' -e 's/,$//g')
+	else
+		ip_addrs=$(hostname -i | sed -e 's/ /,/g' -e 's/,$//g')
+	fi
 	k_cluster_ip="10.0.0.1"
 	cfssl gencert -loglevel="$loglevel" \
 		-ca="${master_d}/ca.pem" \


### PR DESCRIPTION
The original 'hostname' command provided by the project 'net-tools'
doesn't support the option '-I' (see last comment of the 'net-tools'
webpage [1]).

Those tools invoking 'hostname' with the option '-I' (rootlesskit.sh
and cfssl.sh at the time of this writing) work on distros using a
version of 'hostname' supporting '-I' (basically Debian and RedHat
derivatives) out of the box. But it doesn't on those using the original
'hostname' (like ArchLinux and derivatives).

This patch adds support for ArchLinux and derivatives using the default
distro 'hostname' by falling back to using '-i' on those systems not
supporting the option '-I'. The only difference is that it depends on
name resolution (see [2] for the documentation of the option '-I').

[1] https://net-tools.sourceforge.io/
[2] https://linux.die.net/man/1/hostname

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>

Closes #223 