### PR TITLE
There is no multi-user.target in --user mode systemd.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -242,7 +242,7 @@ Requires=u7s-master-with-etcd.target u7s-node.target
 After=u7s-master-with-etcd.target u7s-node.target
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 EOF
 
 cat <<EOF | x u7s-master-with-etcd.target


### PR DESCRIPTION
#278  solved by using default.target , because systemd in user mode don`t contain multi-user.target
```
systemctl --user -t target
```

![image](https://user-images.githubusercontent.com/41143306/231242948-e0bcbbbe-b6d3-4315-93d4-29a7a69a53d7.png)

how to check
enable autostart service
```
systemctl --user enable u7s.target
```
but command doesn't show any dependensies
```
systemctl --user list-dependencies multi-user.target
```

after changing to default.target
```
systemctl --user list-dependencies default.target
```
![image](https://user-images.githubusercontent.com/41143306/231243547-8aec92b0-3c2b-430f-a305-10dfc52ded07.png)

and for worker node needs to change parameters in u7s.target delete running master node components
```
Requires=u7s-node.target
After=u7s-node.target
```
