### PR TITLE
Support CONTAINER_ENGINE=(podman|nerdctl) in addition to docker

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,12 @@ jobs:
     name: "Single node"
     runs-on: ubuntu-22.04
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [docker, podman]
+    env:
+      CONTAINER_ENGINE: "${{ matrix.engine }}"
     steps:
       - uses: actions/checkout@v3
       - name: Set up cgroup v2 delegation
@@ -19,15 +25,26 @@ jobs:
           Delegate=cpu cpuset io memory pids
           EOF
           sudo systemctl daemon-reload
+      - name: Remove preinstalled Moby
+        # Preinstalled Moby does not contain dockerd-rootless-setuptool.sh
+        run: sudo apt-get remove moby-engine-*
       - name: Set up Rootless Docker
+        if: ${{ matrix.engine == 'docker' }}
         run: |
           set -eux -o pipefail
-          sudo apt-get remove moby-engine-*
           curl https://get.docker.com | sudo sh
           sudo systemctl disable --now docker.socket docker.service
           sudo rm -rf /var/run/docker*
           dockerd-rootless-setuptool.sh install
           docker info
+      - name: Set up Rootless Podman
+        if: ${{ matrix.engine == 'podman' }}
+        run: |
+          set -eux -o pipefail
+          # Preinstalled Podman is too old (v3.4.4)
+          sudo apt-get remove podman*
+          sudo ./init-host/init-host.root.d/install-podman.sh
+          podman info
       - run: make up
       - run: sleep 5
       - run: make kubeadm-init
@@ -46,6 +63,17 @@ jobs:
     name: "Multi node (emulated using LXD)"
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lxc-image: ubuntu:22.04
+            engine: docker
+          - lxc-image: images:fedora/38/cloud
+            engine: podman
+    env:
+      LXC_IMAGE: "${{ matrix.lxc-image }}"
+      CONTAINER_ENGINE: "${{ matrix.engine }}"
     steps:
       - run: sudo modprobe vxlan
       - uses: actions/checkout@v3

--- a/Makefile.d/detect_container_engine.sh
+++ b/Makefile.d/detect_container_engine.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eu -o pipefail
+: "${CONTAINER_ENGINE:=}"
+: "${COMPOSE:=}"
+
+if [ -z "${CONTAINER_ENGINE}" ]; then
+	if command -v dockerd-rootless.sh >/dev/null 2>&1; then
+		CONTAINER_ENGINE=docker
+	elif command -v containerd-rootless.sh >/dev/null 2>&1; then
+		CONTAINER_ENGINE=nerdctl
+	elif command -v podman >/dev/null 2>&1; then
+		CONTAINER_ENGINE=podman
+	else
+		echo >&2 "$0: no container engine was detected"
+		exit 1
+	fi
+fi
+
+CONTAINER_ENGINE_TYPE=docker
+if [[ "${CONTAINER_ENGINE}" = *"podman"* ]]; then
+	CONTAINER_ENGINE_TYPE=podman
+elif [[ "${CONTAINER_ENGINE}" = *"nerdctl"* ]]; then
+	CONTAINER_ENGINE_TYPE=nerdctl
+fi
+
+if [ -z "${COMPOSE}" ]; then
+	COMPOSE="${CONTAINER_ENGINE} compose"
+	if [ "${CONTAINER_ENGINE_TYPE}" = "podman" ]; then
+		COMPOSE=podman-compose
+	fi
+fi
+
+case "$#" in
+0)
+	echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}"
+	echo "CONTAINER_ENGINE_TYPE=${CONTAINER_ENGINE_TYPE}"
+	echo "COMPOSE=${COMPOSE}"
+	;;
+1)
+	case "$1" in
+	"CONTAINER_ENGINE" | "CONTAINER_ENGINE_TYPE" | "COMPOSE")
+		echo "${!1}"
+		;;
+	*)
+		echo >&2 "$0: unknown argument: $1"
+		exit 1
+		;;
+	esac
+	;;
+*)
+	echo >&2 "$0: too many arguments"
+	exit 1
+	;;
+esac

--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ but Usernetes (Gen 2) supports creating a cluster with multiple hosts.
 
 ## Requirements
 
-- Host OS should be one of the following:
-  - Ubuntu 22.04 (recommended)
-  - Rocky Linux 9
-  - AlmaLinux 9
+- One of the following host operating system:
 
-- [Rootless Docker](https://rootlesscontaine.rs/getting-started/docker/):
+|Host operating system|Minimum version|
+|---------------------|---------------|
+|Ubuntu (recommended) |22.04          |
+|Rocky Linux          |9              |
+|AlmaLinux            |9              |
+|Fedora               |(?)            |
+
+- One of the following container engines:
+
+|Container Engine                                                                    |Minimum version|
+|------------------------------------------------------------------------------------|---------------|
+|[Rootless Docker](https://rootlesscontaine.rs/getting-started/docker/) (recommended)|v20.10         |
+|[Rootless Podman](https://rootlesscontaine.rs/getting-started/podman/)              |v4.x           |
+|[Rootless nerdctl](https://rootlesscontaine.rs/getting-started/containerd/)         |v1.6           |
+
 ```bash
 curl -o install.sh -fsSL https://get.docker.com
 sudo sh install.sh
@@ -97,6 +108,9 @@ make shell
 make down-v
 kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 ```
+
+The container engine defaults to Docker.
+To change the container engine, set `export CONTAINER_ENGINE=podman` or `export CONTAINER_ENGINE=nerdctl`.
 
 ## Limitations
 - Node ports cannot be exposed automatically. Edit [`docker-compose.yaml`](./docker-compose.yaml) for exposing additional node ports.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,7 @@ services:
     build: .
     hostname: ${U7S_NODE_NAME}
     privileged: true
-    restart: on-failure
-    tty: true
+    restart: always
     ports:
       # etcd
       - 2379:2379

--- a/hack/create-cluster-lxd.sh
+++ b/hack/create-cluster-lxd.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
 set -eux -o pipefail
 
+: "${CONTAINER_ENGINE:=docker}"
+
 # Create Rootless Docker hosts
 ./hack/create-hosts-lxd.sh "${HOME}/.u7s-ci-hosts" host0 host1
 SCP="scp -F ${HOME}/.u7s-ci-hosts/ssh_config"
 SSH="ssh -F ${HOME}/.u7s-ci-hosts/ssh_config"
 for host in host0 host1; do
 	$SCP -r "$(pwd)" "${host}:~/usernetes"
-	$SSH "${USER}-sudo@${host}" sudo "~${USER}/usernetes/init-host/init-host.root.sh"
+	$SSH "${USER}-sudo@${host}" sudo CONTAINER_ENGINE="${CONTAINER_ENGINE}" "~${USER}/usernetes/init-host/init-host.root.sh"
 	$SSH "${USER}-sudo@${host}" sudo loginctl enable-linger "${USER}"
-	$SSH "${host}" ~/usernetes/init-host/init-host.rootless.sh
+	$SSH "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" ~/usernetes/init-host/init-host.rootless.sh
 done
 
 # Launch a Kubernetes node inside a Rootless Docker host
 for host in host0 host1; do
-	$SSH "${host}" make -C ~/usernetes up
+	$SSH "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C ~/usernetes up
 done
 
 # Bootstrap a cluster with host0
-$SSH host0 make -C ~/usernetes kubeadm-init install-flannel kubeconfig join-command
+$SSH host0 CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C ~/usernetes kubeadm-init install-flannel kubeconfig join-command
 
 # Let host1 join the cluster
 $SCP host0:~/usernetes/join-command host1:~/usernetes/join-command
-$SSH host1 make -C ~/usernetes kubeadm-join
+$SSH host1 CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C ~/usernetes kubeadm-join
 
 # Enable kubectl
 $SCP host0:~/usernetes/kubeconfig ./kubeconfig

--- a/hack/create-hosts-lxd.sh
+++ b/hack/create-hosts-lxd.sh
@@ -8,6 +8,7 @@ dir=$1
 shift
 names=$*
 
+: "${LXC_IMAGE:="ubuntu:22.04"}"
 LXC="sudo lxc"
 
 echo "USER=${USER}"
@@ -42,7 +43,7 @@ EOF
 fi
 
 for name in ${names}; do
-	${LXC} init ubuntu:22.04 "${name}" -c security.privileged=true -c security.nesting=true
+	${LXC} init "${LXC_IMAGE}" "${name}" -c security.privileged=true -c security.nesting=true
 	${LXC} config device add "${name}" bind-boot disk source=/boot path=/boot readonly=true
 	${LXC} config set "${name}" user.user-data - <"${userdata}"
 	${LXC} start "${name}"

--- a/init-host/init-host.root.d/install-podman.sh
+++ b/init-host/init-host.root.d/install-podman.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script installs the latest release of Podman.
+# Repository information is from https://podman.io/docs/installation#linux-distributions
+set -eux -o pipefail
+if [ "$(id -u)" != "0" ]; then
+	echo "Must run as the root"
+	exit 1
+fi
+
+if command -v dnf >/dev/null 2>&1; then
+	dnf install -y podman podman-compose
+else
+	mkdir -p /etc/apt/keyrings
+	curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" |
+		gpg --dearmor |
+		tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg >/dev/null
+	echo \
+		"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
+        https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" |
+		tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list >/dev/null
+	apt-get update -qq
+	apt-get -qq -y install podman
+	# No dpkg for podman-compose ?
+	pip3 install podman-compose
+fi

--- a/init-host/init-host.rootless.sh
+++ b/init-host/init-host.rootless.sh
@@ -6,5 +6,17 @@ if [ "$(id -u)" == "0" ]; then
 	exit 1
 fi
 
-dockerd-rootless-setuptool.sh install
-docker info
+: "${CONTAINER_ENGINE:=docker}"
+case "${CONTAINER_ENGINE}" in
+"docker")
+	dockerd-rootless-setuptool.sh install
+	;;
+"podman")
+	systemctl --user enable --now podman-restart
+	;;
+*)
+	# NOP
+	;;
+esac
+
+${CONTAINER_ENGINE} info


### PR DESCRIPTION
- Dockerfile: Use long image names with the `docker.io/` prefix for compatibility with Red Hat's containers
- Dockerfile: Avoid using BuildKit features that are unsupported by buildah
- docker-compose.yaml: Set the restart mode to `always`, as required by [`podman-restart.service`](https://github.com/containers/podman/blob/v4.6.2/contrib/systemd/system/podman-restart.service.in#L12)
- docker-compose.yaml: Remove `tty: true`, as it is unsupported by `nerdctl compose up -d`.
- Makefile: Remove `$(COMPOSE) cp`, as it is unsupported by podman-compose

nerdctl support depends on:
- containerd/nerdctl#2507 (milestone: nerdctl v1.6.0)