### PR TITLE
Remove warning about linger from older systemd

### DIFF
--- a/Makefile.d/check-preflight.sh
+++ b/Makefile.d/check-preflight.sh
@@ -58,7 +58,7 @@ esac
 if [ "${rootless}" = "1" ]; then
 	# Check systemd lingering: https://rootlesscontaine.rs/getting-started/common/login/
 	if command -v loginctl >/dev/null 2>&1; then
-		if [ "$(loginctl list-users --output json | jq ".[] | select(.uid == "${UID}").linger")" != "true" ]; then
+		if [ "$(loginctl show-user --property Linger "${UID}")" != "Linger=yes" ]; then
 			WARNING 'systemd lingering is not enabled. Run `sudo loginctl enable-linger $(whoami)` to enable it, otherwise Kubernetes will exit on logging out.'
 		fi
 	else


### PR DESCRIPTION
Older versions of systemd do not include linger information:

```
$ loginctl list-users --output json 
[{"uid":1000,"user":"anders"}]
```

So usernetes will always show the warning, even if it is enabled.

```
+ loginctl enable-linger anders
[INFO] To run docker.service on system startup, run: `sudo loginctl enable-linger anders`
[WARNING] systemd lingering is not enabled. Run `sudo loginctl enable-linger $(whoami)` to enable it, otherwise Kubernetes will exit on logging out.
```