### PR TITLE
ci: add test for rootful docker

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,16 +20,23 @@ jobs:
         include:
           - lima_template: template://ubuntu-24.04
             container_engine: docker
+            rootful: "false"
+          - lima_template: template://docker-rootful
+            container_engine: docker
+            rootful: "true"
           - lima_template: template://ubuntu-24.04
             container_engine: nerdctl
+            rootful: "false"
           - lima_template: template://centos-stream-9
             container_engine: podman
           - lima_template: template://fedora
             container_engine: podman
+            rootful: "false"
     uses: ./.github/workflows/reusable-multi-node.yaml
     with:
       lima_template: ${{ matrix.lima_template }}
       container_engine: ${{ matrix.container_engine }}
+      rootful: ${{ matrix.rootful }}
 
   # TODO: this test should create multiple instances of Usernetes on each of the hosts
   multi-node-custom-ports:

--- a/.github/workflows/reusable-multi-node.yaml
+++ b/.github/workflows/reusable-multi-node.yaml
@@ -19,6 +19,10 @@ on:
         description: flannel vxlan port
         type: string
         default: "8472"
+      rootful:
+        description: use rootful mode for a container technology
+        type: string
+        default: "false"
       etcd_port:
         description: etcd service port
         type: string
@@ -41,6 +45,7 @@ jobs:
     env:
       LIMA_TEMPLATE: "${{ inputs.lima_template }}"
       CONTAINER_ENGINE: "${{ inputs.container_engine }}"
+      CONTAINER_ROOTFUL: "${{ inputs.rootful }}"
       PORT_KUBE_APISERVER: "${{ inputs.kube_apiserver_port }}"
       PORT_FLANNEL: "${{ inputs.flannel_port }}"
       PORT_KUBELET: "${{ inputs.kubelet_port }}"

--- a/Dockerfile.d/etc_udev_rules.d_90-flannel.rules
+++ b/Dockerfile.d/etc_udev_rules.d_90-flannel.rules
@@ -3,3 +3,4 @@
 # https://github.com/kubernetes/kops/pull/9074
 # https://github.com/karmab/kcli/commit/b1a8eff658d17cf4e28162f0fa2c8b2b10e5ad00
 SUBSYSTEM=="net", ACTION=="add|change|move", ENV{INTERFACE}=="flannel.1", RUN+="/usr/sbin/ethtool -K flannel.1 tx-checksum-ip-generic off"
+SUBSYSTEM=="net", ACTION=="add|change|move", ENV{INTERFACE}=="eth0", RUN+="/usr/sbin/ethtool tx-checksum-ip-generic off"

--- a/hack/create-cluster-lima.sh
+++ b/hack/create-cluster-lima.sh
@@ -24,7 +24,7 @@ for host in host0 host1; do
 	# Set --plain to minimize Limaism
 	${LIMACTL} start --plain --network lima:user-v2 --name="${host}" ${LIMACTL_CREATE_ARGS} "${LIMA_TEMPLATE}"
 	${LIMACTL} copy -r "$(pwd)" "${host}:${guest_home}/usernetes"
-	${LIMACTL} shell "${host}" sudo CONTAINER_ENGINE="${CONTAINER_ENGINE}" "${guest_home}/usernetes/init-host/init-host.root.sh"
+	${LIMACTL} shell "${host}" sudo CONTAINER_ENGINE="${CONTAINER_ENGINE}" CONTAINER_ROOTFUL="${CONTAINER_ROOTFUL}" "${guest_home}/usernetes/init-host/init-host.root.sh"
 	# Terminate the current session so that the cgroup delegation takes an effect. This command exits with status 255 as SSH terminates.
 	${LIMACTL} shell "${host}" sudo loginctl terminate-user "${USER}" || true
 	${LIMACTL} shell "${host}" sudo loginctl enable-linger "${USER}"
@@ -32,7 +32,7 @@ for host in host0 host1; do
 		# Lockdown sudo to ensure rootless-ness
 		${LIMACTL} shell "${host}" sudo sh -euxc 'rm -rf /etc/sudoers.d/*-cloud-init-users'
 	fi
-	${LIMACTL} shell "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" "${guest_home}/usernetes/init-host/init-host.rootless.sh"
+	${LIMACTL} shell "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" CONTAINER_ROOTFUL="${CONTAINER_ROOTFUL}" "${guest_home}/usernetes/init-host/init-host.rootless.sh"
 done
 
 SERVICE_PORTS="PORT_KUBE_APISERVER=${PORT_KUBE_APISERVER} PORT_ETCD=${PORT_ETCD} PORT_FLANNEL=${PORT_FLANNEL} PORT_KUBELET=${PORT_KUBELET}"

--- a/init-host/init-host.rootless.sh
+++ b/init-host/init-host.rootless.sh
@@ -7,10 +7,23 @@ if [ "$(id -u)" == "0" ]; then
 fi
 
 : "${CONTAINER_ENGINE:=docker}"
+: "${CONTAINER_ROOTFUL:=false}"
 : "${XDG_CONFIG_HOME:=${HOME}/.config}"
+
+setup_docker_rootless() {
+	if [ "${CONTAINER_ROOTFUL}" = "true" ]; then
+		return
+	fi
+	dockerd-rootless-setuptool.sh install || (journalctl --user --since "10 min ago"; exit 1)
+}
+
 case "${CONTAINER_ENGINE}" in
 "docker")
-	dockerd-rootless-setuptool.sh install || (journalctl --user --since "10 min ago"; exit 1)
+	setup_docker_rootless
+	;;
+"docker-rootful")
+	echo "Skipping rootless install of docker"
+	CONTAINER_ENGINE="docker"
 	;;
 "nerdctl")
 	containerd-rootless-setuptool.sh install


### PR DESCRIPTION
I am finding with testing that the networking between hosts does not work when we are running in rootful. I was testing this because using nvidia devices _does_ work with rootful, but once I got to the stop of needing pods to communicate, there was no communication.

I am not sure about the error, but this test should reproduce it in CI. Note that to enable this we use the docker-rootful template provided by lima (@AkihiroSuda you have thought of all things)! The main changes here are to add this test to the matrix, and ensure that in the different install scripts, we largely do nothing if the container runtime is `docker-rootful`.

Related to #365 but does not fix it, only demonstrates it.