### PR TITLE
docs: note on order of starting components

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ pasta does not seem to work well
 Use scripts in [`./init-host`](./init-host) for automating these steps.
 
 ## Usage
+
 See `make help`.
 
 ```bash
@@ -170,7 +171,7 @@ make up
 
 ### Multi-tenancy
 
-Multiple users on the hosts may create their own instances of Usernetes, but the port numbers have to be changed to avoid conflicts.
+Multiple users on the hosts may create their own instances of Usernetes. For systems that do not allow the lower port range, or for multiple usernetes deployments on the same physical node (experimental), the port numbers can be changed.
 
 ```bash
 # Default: 2379
@@ -186,6 +187,8 @@ make up
 ```
 
 ![docs/images/multi-tenancy.png](./docs/images/multi-tenancy.png)
+
+In addition, for multi-host, you will want to `make install-flannel` after `make sync-external-ip` when worker pods are up. The sync command adds an annotation `flannel.alpha.coreos.com/public-ip-overwrite` for flannel to direct the nodes to use the physical node host IP. If the flannel pod has already been created for a node, it would need to be restarted to recheck the annotation. The easiest approach is to install flannel after the annotations have been applied.
 
 ### Rootful mode
 Although Usernetes (Gen2) is designed to be used with Rootless Docker, it should work with the regular "rootful" Docker too.


### PR DESCRIPTION
@AkihiroSuda - this is a small note for the README to comment on the order of installing components. As you know, the setup uses annotation targeted at flannel to use a host external ip for a multi-node setup. The issue arises with order of operations. If we install flannel with the control plane, that means when new nodes come up, their flannel pods will be created (along with the control plane) to use the "host" discovered IP, which is the usernetes 10.x one.  If these addresses that are in the private space can be routed between nodes (possible in some clouds) this is not an issue. It becomes an issue in an HPC or similar environment where the private 10.x address goes to a router and is not known, and the packets are dropped. We ran into this issue on our HPC system, and I realized it was because of the order of operations - we should make sync-external-ip first (adding the annotation) and then make install-flannel to use it. This would only be a bug for specific, multi-node environments. In summary, the current instructions describe:

```console
bring up control plane
install flannel

bring up workers
add annotation and patches
```

And the order should be:

```console
bring up control plane
bring up workers
add annotation and patches
install flannel
```