### PR TITLE
bug: multi-node setup needs unique network names

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ pasta does not seem to work well
 Use scripts in [`./init-host`](./init-host) for automating these steps.
 
 ## Usage
+
 See `make help`.
+
+Here are instructions for control plane and worker nodes.
 
 ```bash
 # Bootstrap a cluster

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     privileged: true
     restart: always
     networks:
-      default:
+      ${HOSTNAME}:
         ipv4_address: ${NODE_IP}
     ports:
       # <host>:<container>
@@ -46,7 +46,7 @@ services:
       "nerdctl/bypass4netns-ignore-bind": "true"
       "nerdctl/bypass4netns-ignore-subnets": "${BYPASS4NETNS_IGNORE_SUBNETS:-}"
 networks:
-  default:
+  ${HOSTNAME}:
     ipam:
       config:
         # Each of the nodes has to have a different IP.


### PR DESCRIPTION
In the case of using Podman (or a runtime that has a shared CNI directory in the user home) and the case that the runtime generates a cni file for each node network, if you have a shared filesystem and a single, non-unique name, each node will write a slightly different address in the CNI file and clobber any previously written files (race condition). This additional make multi-node command will replace "default network" to be specific to the hostname and avoid this. 

I renamed the network from `default` to `default_network` so it would be more unique for the sed (default is fairly generic).  If the user doesn't run this (and they don't need to for most setups without a shared cni cache) the network will just be called `usernetes_default_network` instead of `usernetes_default`.