### PR TITLE
Support running Kubernetes-in-Kubernetes, as UserNS-enabled pods

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /kubeconfig
 /kubectl
 /join-command
+/.git

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,45 @@
+---
+# Push the node image to ghcr.io/rootless-containers/usernetes.
+# The image is consumed by the Kubernetes-in-Kubernetes mode (../../kubernetes)
+# as the default value of U7S_IMAGE; the Docker Compose mode builds the image
+# locally and does not use this.
+name: Image
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "gen*-v*"
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  push:
+    name: "Push the node image to GHCR"
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      - uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7  # v4.5.1
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,3 +48,7 @@ jobs:
       kubelet_port: "20250"
       # Defaults to 2379
       etcd_port: "9090"
+
+  k8s-in-k8s:
+    name: "Kubernetes-in-Kubernetes"
+    uses: ./.github/workflows/reusable-k8s-in-k8s.yaml

--- a/.github/workflows/reusable-k8s-in-k8s.yaml
+++ b/.github/workflows/reusable-k8s-in-k8s.yaml
@@ -1,0 +1,297 @@
+name: Kubernetes-in-Kubernetes
+on:
+  workflow_call:
+    inputs:
+      k3s_version:
+        description: k3s version for the outer Kubernetes cluster
+        type: string
+        default: "v1.36.2+k3s1"
+
+permissions:
+  contents: read
+
+jobs:
+  k8s-in-k8s:
+    name: "Usernetes inside Kubernetes (outer cluster using a single-node k3s)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      U7S_IMAGE: usernetes:ci
+      # 127.0.0.1:6443 is used by the API server of the outer cluster (k3s),
+      # so the API server of the inner cluster is forwarded to another port.
+      U7S_KUBE_APISERVER_LOCAL_PORT: "16443"
+      # The "usernetes" RuntimeClass is backed by a dedicated containerd
+      # runtime handler with cgroup_writable = true; see below.
+      U7S_RUNTIME_CLASS_NAME: usernetes
+      K3S_VERSION: "${{ inputs.k3s_version }}"
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+    defaults:
+      run:
+        working-directory: kubernetes
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load kernel modules
+        run: |
+          sudo modprobe br_netfilter
+          sudo modprobe vxlan
+
+      - name: Create the outer Kubernetes cluster (k3s)
+        run: |
+          set -eux -o pipefail
+          command -v envsubst >/dev/null 2>&1 || sudo apt-get install -y gettext-base
+          curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${K3S_VERSION}" K3S_KUBECONFIG_MODE=644 sh -s - server --disable=traefik,servicelb,metrics-server
+          timeout 120 bash -c 'until kubectl get nodes >/dev/null 2>&1; do sleep 2; done'
+          kubectl wait --for=condition=Ready node --all --timeout=5m
+          kubectl get nodes -o wide
+
+      - name: Define the "usernetes" runtime handler in the containerd of the outer cluster
+        run: |
+          set -eux -o pipefail
+          # systemd inside the node pods has to be able to manage its own
+          # (namespaced) cgroups: with `cgroup_writable = true`, containerd
+          # (>= 2.1) mounts /sys/fs/cgroup read-write, and runc chowns the
+          # cgroup of the container to the mapped root of the user namespace.
+          #
+          # cgroup_writable is enabled only for a dedicated "usernetes"
+          # runtime handler (exposed to the pods via the "usernetes"
+          # RuntimeClass below), not for the default "runc" handler.
+          conf_dir=/var/lib/rancher/k3s/agent/etc/containerd
+          sudo tee "${conf_dir}/config-v3.toml.tmpl" >/dev/null <<'EOF'
+          {{ template "base" . }}
+
+          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.usernetes]
+            runtime_type = "io.containerd.runc.v2"
+            cgroup_writable = true
+            [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.usernetes.options]
+              SystemdCgroup = true
+          EOF
+          sudo systemctl restart k3s
+          timeout 120 bash -c 'until kubectl get nodes >/dev/null 2>&1; do sleep 2; done'
+          kubectl wait --for=condition=Ready node --all --timeout=5m
+          # k3s re-renders config.toml from the template on startup
+          sudo grep -A4 'runtimes.usernetes' "${conf_dir}/config.toml"
+
+      - name: Create the "usernetes" RuntimeClass
+        run: |
+          kubectl apply -f - <<EOF
+          apiVersion: node.k8s.io/v1
+          kind: RuntimeClass
+          metadata:
+            name: usernetes
+          handler: usernetes
+          EOF
+
+      - name: Build the node image
+        working-directory: .
+        run: docker build -t "${U7S_IMAGE}" .
+
+      - name: Load the node image into the outer cluster
+        run: docker save "${U7S_IMAGE}" | sudo k3s ctr images import -
+
+      - run: make up
+
+      - name: Verify that the node pods are running in user namespaces
+        run: |
+          set -eux -o pipefail
+          uid_map="$(kubectl exec --namespace=usernetes u7s-control-plane-0 -c node -- cat /proc/1/uid_map)"
+          echo "uid_map of the control plane pod: ${uid_map}"
+          if echo "${uid_map}" | grep -qw 4294967295; then
+            echo >&2 "ERROR: the node pod does not seem to be running in a user namespace"
+            exit 1
+          fi
+
+      - run: make kubeadm-init
+      - run: make install-flannel
+      - run: make kubeadm-join
+
+      - name: make kubeconfig
+        run: |
+          set -eux -o pipefail
+          make kubeconfig
+          nohup bash -c 'while true; do make port-forward; sleep 1; done' >/tmp/port-forward.log 2>&1 &
+          timeout 60 bash -c 'until kubectl --kubeconfig=./kubeconfig version >/dev/null 2>&1; do sleep 2; done'
+
+      - name: Smoke test
+        working-directory: .
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+          ./hack/test-smoke.sh
+
+      # Multi-tenancy: multiple inner clusters can be created in the same
+      # outer cluster by using different namespaces.
+      - name: "Multi-tenancy: create a second inner cluster in another namespace"
+        env:
+          U7S_NAMESPACE: usernetes2
+          U7S_KUBE_APISERVER_LOCAL_PORT: "26443"
+        run: |
+          set -eux -o pipefail
+          make up
+          make kubeadm-init
+          make install-flannel
+          make kubeadm-join
+          # `make kubeconfig` writes to ./kubeconfig, which still holds the
+          # kubeconfig of the first tenant, so shelter the existing file.
+          mv kubeconfig kubeconfig1
+          make kubeconfig
+          mv kubeconfig kubeconfig2
+          mv kubeconfig1 kubeconfig
+          nohup bash -c 'while true; do make port-forward; sleep 1; done' >/tmp/port-forward2.log 2>&1 &
+          timeout 60 bash -c 'until kubectl --kubeconfig=./kubeconfig2 version >/dev/null 2>&1; do sleep 2; done'
+
+      - name: "Multi-tenancy: verify that the node pods of the two tenants do not share UID ranges"
+        run: |
+          set -eux -o pipefail
+          # The kubelet allocates a distinct UID range (65536 IDs) to every
+          # UserNS-enabled pod on the node; /etc/subuid is not involved.
+          uid_map_offsets="$(for ns in usernetes usernetes2; do
+            for pod in u7s-control-plane-0 u7s-worker-0; do
+              kubectl exec --namespace="${ns}" "${pod}" -c node -- awk '$1 == "0" {print $2}' /proc/1/uid_map
+            done
+          done)"
+          echo "${uid_map_offsets}"
+          test "$(echo "${uid_map_offsets}" | sort -u | wc -l)" -eq 4
+
+      - name: "Multi-tenancy: smoke test (the second inner cluster)"
+        working-directory: .
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig2"
+        run: |
+          kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+          ./hack/test-smoke.sh
+
+      - name: "Multi-tenancy: verify that the first inner cluster is still functional"
+        working-directory: .
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          set -eux -o pipefail
+          kubectl wait --for=condition=Ready node --all --timeout=1m
+          kubectl get nodes -o wide
+
+      - if: failure()
+        name: "Debug (outer cluster)"
+        run: |
+          set -x
+          kubectl get nodes -o wide
+          kubectl get pods -A -o wide
+          kubectl --namespace=usernetes describe pods
+          kubectl --namespace=usernetes logs u7s-control-plane-0 --all-containers --tail=100 || true
+          kubectl --namespace=usernetes exec u7s-control-plane-0 -- journalctl --no-pager | tail -n 300 || true
+          kubectl --namespace=usernetes2 describe pods || true
+          kubectl --namespace=usernetes2 logs u7s-control-plane-0 --all-containers --tail=100 || true
+          sudo journalctl -u k3s --no-pager | tail -n 100 || true
+          cat /tmp/port-forward.log || true
+          cat /tmp/port-forward2.log || true
+
+      - if: failure()
+        name: "Debug (inner cluster)"
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          set -x
+          kubectl get nodes -o wide || true
+          kubectl get nodes -o yaml || true
+          kubectl get pods -A -o wide || true
+
+  k8s-in-k8s-multi-node:
+    name: "Usernetes inside Kubernetes (multi-node outer cluster emulated using Lima)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      U7S_IMAGE: usernetes:ci
+      # 127.0.0.1:6443 is forwarded by Lima to the API server of the outer
+      # cluster, so the API server of the inner cluster is forwarded to
+      # another port.
+      U7S_KUBE_APISERVER_LOCAL_PORT: "16443"
+      U7S_RUNTIME_CLASS_NAME: usernetes
+    defaults:
+      run:
+        working-directory: kubernetes
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: lima-vm/lima-actions/setup@v1
+        id: lima-actions-setup
+
+      - name: "Cache ~/.cache/lima"
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/lima
+          key: lima-${{ steps.lima-actions-setup.outputs.version }}
+
+      - name: Create the outer Kubernetes cluster (two nodes)
+        working-directory: .
+        run: |
+          set -eux -o pipefail
+          command -v envsubst >/dev/null 2>&1 || sudo apt-get install -y gettext-base
+          ./hack/create-outer-cluster-lima.sh
+          echo "KUBECONFIG=${HOME}/.lima/host0/copied-from-guest/kubeconfig.yaml" >>"$GITHUB_ENV"
+
+      - name: Build the node image
+        working-directory: .
+        run: docker build -t "${U7S_IMAGE}" .
+
+      - name: Load the node image into the outer cluster
+        run: |
+          set -eux -o pipefail
+          docker save "${U7S_IMAGE}" -o /tmp/u7s-image.tar
+          for host in host0 host1; do
+            limactl copy /tmp/u7s-image.tar "${host}:/tmp/u7s-image.tar"
+            limactl shell "${host}" sudo nerdctl --namespace=k8s.io load -i /tmp/u7s-image.tar
+          done
+
+      - run: make up
+
+      - name: Verify that the node pods are spread across the outer nodes
+        run: |
+          set -eux -o pipefail
+          kubectl get pods --namespace=usernetes -o wide
+          test "$(kubectl get pods --namespace=usernetes -o jsonpath='{.items[*].spec.nodeName}' | tr ' ' '\n' | sort -u | wc -l)" -eq 2
+
+      - run: make kubeadm-init
+      - run: make install-flannel
+      - run: make kubeadm-join
+
+      - name: make kubeconfig
+        run: |
+          set -eux -o pipefail
+          make kubeconfig
+          nohup bash -c 'while true; do make port-forward; sleep 1; done' >/tmp/port-forward.log 2>&1 &
+          timeout 60 bash -c 'until kubectl --kubeconfig=./kubeconfig version >/dev/null 2>&1; do sleep 2; done'
+
+      # The DNS test of test-smoke.sh connects to the pods on both of the
+      # inner nodes, i.e., the inner Flannel VXLAN traffic crosses the
+      # outer nodes.
+      - name: Smoke test
+        working-directory: .
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+          ./hack/test-smoke.sh
+
+      - if: failure()
+        name: "Debug (outer cluster)"
+        run: |
+          set -x
+          kubectl get nodes -o wide
+          kubectl get pods -A -o wide
+          kubectl --namespace=usernetes describe pods
+          kubectl --namespace=usernetes logs u7s-control-plane-0 --all-containers --tail=100 || true
+          kubectl --namespace=usernetes logs u7s-worker-0 --all-containers --tail=100 || true
+          limactl shell host0 sudo journalctl --no-pager | tail -n 100 || true
+          limactl shell host1 sudo journalctl --no-pager | tail -n 100 || true
+          cat /tmp/port-forward.log || true
+
+      - if: failure()
+        name: "Debug (inner cluster)"
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          set -x
+          kubectl get nodes -o wide || true
+          kubectl get nodes -o yaml || true
+          kubectl get pods -A -o wide || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /kubeconfig
 /kubectl
 /join-command
+/kubernetes/kubeconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   socat
 ADD Dockerfile.d/etc_udev_rules.d_90-flannel.rules /etc/udev/rules.d/90-flannel.rules
 ADD Dockerfile.d/u7s-entrypoint.sh /
+# Copy the source tree into the image, so that the image is usable without
+# bind-mounting the source tree from the host (e.g., when running inside
+# Kubernetes; see ./kubernetes). In the Docker Compose mode, this directory is
+# shadowed by a read-only bind mount of the current directory.
+COPY . /usernetes
 ENTRYPOINT ["/u7s-entrypoint.sh", "/usr/local/bin/entrypoint", "/sbin/init"]

--- a/Dockerfile.d/u7s-entrypoint.sh
+++ b/Dockerfile.d/u7s-entrypoint.sh
@@ -7,4 +7,19 @@ sed -e "s!\(^KUBELET_EXTRA_ARGS=.*\)!\\1 --cloud-provider=external --node-labels
 # Import control plane hosts from previous boot
 [ -e /etc/hosts.u7s ] && cat /etc/hosts.u7s >>/etc/hosts
 
+# Set sysctls in the container's network namespace (best-effort).
+# In the Docker Compose mode, these are set via docker-compose.yaml and the
+# host configuration. When running as a Kubernetes pod (../kubernetes), they
+# have to be set here, as "unsafe" sysctls cannot be set via the pod spec
+# without reconfiguring the kubelet of the outer cluster.
+if [ "$(cat /proc/sys/net/ipv4/ip_forward)" != "1" ]; then
+	echo 1 >/proc/sys/net/ipv4/ip_forward || echo >&2 "Failed to enable net.ipv4.ip_forward"
+fi
+# rp_filter must be 0 (disabled) or 2 (loose), must not be 1 (strict)
+for f in /proc/sys/net/ipv4/conf/default/rp_filter /proc/sys/net/ipv4/conf/all/rp_filter; do
+	if [ "$(cat "$f")" == "1" ]; then
+		echo 2 >"$f" || echo >&2 "Failed to set ${f} to 2 (loose)"
+	fi
+done
+
 exec "$@"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ export PORT_KUBELET ?= 10250
 export PORT_FLANNEL ?= 8472
 export PORT_KUBE_APISERVER ?= 6443
 
+# POD_SUBNET and SERVICE_SUBNET are the subnets of the cluster,
+# referenced by kubeadm-config.yaml and Makefile.d/install-flannel.sh.
+# The Kubernetes-in-Kubernetes mode (./kubernetes/Makefile) uses different
+# defaults so as not to overlap with the subnets of the outer cluster.
+export POD_SUBNET ?= 10.244.0.0/16
+export SERVICE_SUBNET ?= 10.96.0.0/16
+
 # HOSTNAME is the name of the physical host
 export HOSTNAME ?= $(shell hostname)
 # HOST_IP is the IP address of the physical host. Accessible from other hosts.
@@ -37,12 +44,14 @@ NODE_SHELL := $(COMPOSE) exec \
 	-e PORT_FLANNEL=$(PORT_FLANNEL) \
 	-e PORT_KUBELET=$(PORT_KUBELET) \
 	-e PORT_ETCD=$(PORT_ETCD) \
+	-e POD_SUBNET=$(POD_SUBNET) \
+	-e SERVICE_SUBNET=$(SERVICE_SUBNET) \
 	$(NODE_SERVICE_NAME)
 
 ifeq ($(CONTAINER_ENGINE),nerdctl)
 ifneq (,$(wildcard $(XDG_RUNTIME_DIR)/bypass4netnsd.sock))
 	export BYPASS4NETNS := true
-	export BYPASS4NETNS_IGNORE_SUBNETS := ["10.96.0.0/16", "10.244.0.0/16", "$(NODE_SUBNET)"]
+	export BYPASS4NETNS_IGNORE_SUBNETS := ["$(SERVICE_SUBNET)", "$(POD_SUBNET)", "$(NODE_SUBNET)"]
 endif
 endif
 

--- a/Makefile.d/install-flannel.sh
+++ b/Makefile.d/install-flannel.sh
@@ -4,9 +4,12 @@ set -eu -o pipefail
 # See chart values, 0 indicates default for platform
 # https://github.com/flannel-io/flannel/blob/v0.26.1/chart/kube-flannel/values.yaml
 : "${PORT_FLANNEL:='0'}"
+# Must correspond to the podSubnet of kubeadm-config.yaml.
+# Set via the Makefiles (../Makefile and ../kubernetes/Makefile).
+: "${POD_SUBNET:?}"
 
 if ! helm -n kube-flannel list -q | grep flannel; then
 	kubectl create namespace kube-flannel
 	kubectl label --overwrite namespace kube-flannel pod-security.kubernetes.io/enforce=privileged
-	helm install flannel --namespace kube-flannel --set-json flannel.backendPort=${PORT_FLANNEL} /flannel
+	helm install flannel --namespace kube-flannel --set-json flannel.backendPort=${PORT_FLANNEL} --set podCidr="${POD_SUBNET}" /flannel
 fi

--- a/README.md
+++ b/README.md
@@ -1,24 +1,32 @@
-# Usernetes: Kubernetes without the root privileges (Generation 2)
+# Usernetes: Kubernetes without the root privileges (Generation 3)
 
-Usernetes (Gen2) deploys a Kubernetes cluster inside [Rootless Docker](https://rootlesscontaine.rs/getting-started/docker/),
+Usernetes deploys a Kubernetes cluster without requiring root privileges on the host,
 so as to mitigate potential container-breakout vulnerabilities.
 
-> [!NOTE]
->
-> Usernetes (Gen2) has *significantly* diverged from the original Usernetes (Gen1),
-> which did not require Rootless Docker to be installed on hosts.
->
-> See the [`gen1`](https://github.com/rootless-containers/usernetes/tree/gen1) branch for
-> the original Usernetes (Gen1).
+Two deployment modes are supported:
+- **Kubernetes-in-Docker** (default): Deploys a Kubernetes cluster inside [Rootless Docker](https://rootlesscontaine.rs/getting-started/docker/), [Rootless Podman](https://rootlesscontaine.rs/getting-started/podman/), or [Rootless nerdctl](https://rootlesscontaine.rs/getting-started/containerd/).
+  This mode is similar to [Rootless `kind`](https://kind.sigs.k8s.io/docs/user/rootless/) and [Rootless minikube](https://minikube.sigs.k8s.io/docs/drivers/docker/),
+  but Usernetes supports creating a cluster with multiple hosts.
+- [**Kubernetes-in-Kubernetes**](./kubernetes/README.md): Usernetes runs inside an existing Kubernetes cluster, as [UserNS-enabled pods](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) (`hostUsers: false`).
 
-Usernetes (Gen2) is similar to [Rootless `kind`](https://kind.sigs.k8s.io/docs/user/rootless/) and [Rootless minikube](https://minikube.sigs.k8s.io/docs/drivers/docker/),
-but Usernetes (Gen 2) supports creating a cluster with multiple hosts.
+## Project history
+- **Generation 1** ([`gen1`](https://github.com/rootless-containers/usernetes/tree/gen1) branch, 2018-2023):
+  The original Usernetes, implemented in the style of ["Kubernetes The Hard Way"](https://github.com/kelseyhightower/kubernetes-the-hard-way).
+  This generation was hard to use due to lack of support for kubeadm.
+- **Generation 2** ([`gen2`](https://github.com/rootless-containers/usernetes/tree/gen2) branch, 2023-2026):
+  Switched to **Kubernetes-in-Docker** mode for simplicity. This switch enabled supporting kubeadm.
+- **Generation 3** (2026-present):
+  Additionally added support for **Kubernetes-in-Kubernetes** mode.
 
 ## Components
 - Cluster configuration: kubeadm
 - CRI: containerd
 - OCI: runc
 - CNI: Flannel
+
+> [!NOTE]
+> The documentation below is for the **Kubernetes-in-Docker** mode.
+> See [`./kubernetes`](./kubernetes/README.md) for the **Kubernetes-in-Kubernetes** mode.
 
 ## Requirements
 
@@ -147,6 +155,8 @@ Name                  | Type    | Default value
 `PORT_KUBELET`        | Integer | 10250
 `PORT_FLANNEL`        | Integer | 8472
 `PORT_KUBE_APISERVER` | Integer | 6443
+`POD_SUBNET`          | String  | "10.244.0.0/16"
+`SERVICE_SUBNET`      | String  | "10.96.0.0/16"
 
 ## Limitations
 - Node ports cannot be exposed automatically. Edit [`docker-compose.yaml`](./docker-compose.yaml) for exposing additional node ports.
@@ -188,5 +198,5 @@ make up
 ![docs/images/multi-tenancy.png](./docs/images/multi-tenancy.png)
 
 ### Rootful mode
-Although Usernetes (Gen2) is designed to be used with Rootless Docker, it should work with the regular "rootful" Docker too.
+Although Usernetes is designed to be used with Rootless Docker, it should work with the regular "rootful" Docker too.
 This might be useful for some people who are looking for "multi-host" version of [`kind`](https://kind.sigs.k8s.io/) and [minikube](https://minikube.sigs.k8s.io/).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
     environment:
       KUBECONFIG: /etc/kubernetes/admin.conf
       HOST_IP: ${HOST_IP}
+      POD_SUBNET: ${POD_SUBNET}
+      SERVICE_SUBNET: ${SERVICE_SUBNET}
     sysctls:
       - net.ipv4.ip_forward=1
       # In addition, `net.ipv4.conf.default.rp_filter`

--- a/hack/create-outer-cluster-lima.sh
+++ b/hack/create-outer-cluster-lima.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -eux -o pipefail
+
+# Create a two-node Kubernetes cluster to be used as the "outer" cluster
+# of the Kubernetes-in-Kubernetes mode (see ../kubernetes), using Lima's
+# template:k8s, and configure it for Usernetes:
+# - the "usernetes" containerd runtime handler (cgroup_writable = true)
+# - the "usernetes" RuntimeClass
+
+: "${LIMACTL:=limactl --tty=false}"
+: "${LIMACTL_CREATE_ARGS:=}"
+: "${LIMA_TEMPLATE:=template://k8s}"
+
+# host0 provides the control plane.
+${LIMACTL} start --network lima:user-v2 --name=host0 ${LIMACTL_CREATE_ARGS} "${LIMA_TEMPLATE}"
+
+# host1 joins the cluster of host0 as a worker, via the `url`, `token`, and
+# `discoveryTokenCaCertHash` parameters of the template.
+# https://lima-vm.io/docs/examples/containers/kubernetes/
+join_command="$(${LIMACTL} shell host0 sudo kubeadm token create --print-join-command | tr -d '\r')"
+# join_command is like "kubeadm join <URL> --token <TOKEN> --discovery-token-ca-cert-hash <HASH>"
+url="$(echo "${join_command}" | awk '{print $3}')"
+token="$(echo "${join_command}" | awk '{for (i = 1; i < NF; i++) if ($i == "--token") print $(i+1)}')"
+hash="$(echo "${join_command}" | awk '{for (i = 1; i < NF; i++) if ($i == "--discovery-token-ca-cert-hash") print $(i+1)}')"
+${LIMACTL} start --network lima:user-v2 --name=host1 ${LIMACTL_CREATE_ARGS} \
+	--param url="${url}" --param token="${token}" --param discoveryTokenCaCertHash="${hash}" \
+	"${LIMA_TEMPLATE}"
+
+# Define the "usernetes" containerd runtime handler with
+# `cgroup_writable = true` (containerd >= 2.1), so that systemd inside
+# the node pods can manage its own (namespaced) cgroups.
+# /etc/containerd/conf.d/*.toml is imported by the containerd config of
+# template:k8s.
+for host in host0 host1; do
+	${LIMACTL} shell "${host}" sudo sh -euxc 'cat >/etc/containerd/conf.d/usernetes.toml <<EOF
+version = 2
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.usernetes]
+          runtime_type = "io.containerd.runc.v2"
+          cgroup_writable = true
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.usernetes.options]
+            SystemdCgroup = true
+EOF
+systemctl restart containerd'
+done
+
+KUBECONFIG="${HOME}/.lima/host0/copied-from-guest/kubeconfig.yaml"
+export KUBECONFIG
+# The `kubeadm join` on host1 may still be in progress when `limactl start`
+# returns, so wait for the node to be registered before waiting for Ready.
+for _ in $(seq 1 60); do
+	test "$(kubectl get nodes --no-headers 2>/dev/null | wc -l)" -ge 2 && break
+	sleep 5
+done
+kubectl wait --for=condition=Ready node --all --timeout=5m
+kubectl get nodes -o wide
+
+# Create the "usernetes" RuntimeClass, corresponding to the containerd
+# runtime handler defined above. To be used as U7S_RUNTIME_CLASS_NAME.
+kubectl apply -f - <<EOF
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: usernetes
+handler: usernetes
+EOF
+
+echo "# The outer cluster is ready. Run the following command by yourself:"
+echo "export KUBECONFIG=${KUBECONFIG}"

--- a/kubeadm-config.yaml
+++ b/kubeadm-config.yaml
@@ -27,8 +27,11 @@ controllerManager:
     - name: cloud-provider
       value: external
 networking:
-  serviceSubnet: "10.96.0.0/16"
-  podSubnet: "10.244.0.0/16"
+  # The defaults (10.96.0.0/16 and 10.244.0.0/16) are set in ./Makefile;
+  # the Kubernetes-in-Kubernetes mode (./kubernetes/Makefile) uses different
+  # defaults so as not to overlap with the subnets of the outer cluster.
+  serviceSubnet: "${SERVICE_SUBNET}"
+  podSubnet: "${POD_SUBNET}"
 etcd:
   local:
     extraArgs:

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -1,0 +1,138 @@
+# Run `make help` to show usage
+.DEFAULT_GOAL := help
+
+# U7S_IMAGE is the image of the node pods, built from the top-level
+# Dockerfile. The default image is pushed to GHCR by the CI
+# (../.github/workflows/image.yaml) on every push to the master branch.
+export U7S_IMAGE ?= ghcr.io/rootless-containers/usernetes:master
+
+# U7S_RUNTIME_CLASS_NAME is the RuntimeClass of the node pods, expected to be
+# backed by a runtime handler with `cgroup_writable = true` (containerd).
+# Empty (default) means the default runtime handler of the outer cluster,
+# which then has to mount /sys/fs/cgroup of the node pods read-write by
+# itself. See ./README.md.
+export U7S_RUNTIME_CLASS_NAME ?=
+
+# U7S_NAMESPACE is the namespace in the outer Kubernetes cluster.
+export U7S_NAMESPACE ?= usernetes
+
+# U7S_WORKER_REPLICAS is the number of the worker node pods.
+export U7S_WORKER_REPLICAS ?= 1
+
+# U7S_POD_SUBNET and U7S_SERVICE_SUBNET are the subnets of the inner cluster.
+# They must not overlap with the subnets used by the outer cluster (pods,
+# services, nodes), so the defaults here differ from the Docker Compose mode
+# (10.244.0.0/16 and 10.96.0.0/16; see ../Makefile), which would clash with
+# typical outer clusters (e.g., kubeadm with flannel, or kind).
+export U7S_POD_SUBNET ?= 10.200.0.0/16
+export U7S_SERVICE_SUBNET ?= 10.201.0.0/16
+
+# U7S_KUBE_APISERVER_LOCAL_PORT is the local port used by `make port-forward`
+# (and written into the kubeconfig by `make kubeconfig`) for reaching the API
+# server of the inner cluster. Set it to a free port when 127.0.0.1:6443 is
+# already taken, e.g., by the API server of the outer cluster (as with k3s).
+export U7S_KUBE_APISERVER_LOCAL_PORT ?= 6443
+
+KUBECTL ?= kubectl
+
+CONTROL_PLANE_POD := u7s-control-plane-0
+# NODE_NAME of the control plane. Must correspond to the value in ./usernetes.yaml .
+CONTROL_PLANE_NODE_NAME := $(CONTROL_PLANE_POD).u7s
+NODE_EXEC := $(KUBECTL) exec --namespace=$(U7S_NAMESPACE)
+
+.PHONY: help
+help:
+	@echo '# Bootstrap a cluster (inside an existing Kubernetes cluster)'
+	@echo 'export U7S_IMAGE=<registry>/usernetes:latest'
+	@echo 'make up'
+	@echo 'make kubeadm-init'
+	@echo 'make install-flannel'
+	@echo 'make kubeadm-join'
+	@echo
+	@echo '# Enable kubectl'
+	@echo 'make kubeconfig'
+	@echo 'make port-forward   # Run in a separate terminal'
+	@echo 'export KUBECONFIG=$$(pwd)/kubeconfig'
+	@echo 'kubectl get pods -A'
+	@echo
+	@echo '# Debug'
+	@echo 'make logs'
+	@echo 'make shell'
+	@echo 'make down'
+
+.PHONY: render
+render:
+	@command -v envsubst >/dev/null 2>&1 || { echo >&2 'Command "envsubst" (GNU gettext) is not installed'; exit 1; }
+	@envsubst '$$U7S_NAMESPACE $$U7S_IMAGE $$U7S_WORKER_REPLICAS $$U7S_POD_SUBNET $$U7S_SERVICE_SUBNET $$U7S_RUNTIME_CLASS_NAME' <usernetes.yaml
+
+.PHONY: up
+up:
+	$(MAKE) --silent render | $(KUBECTL) apply -f -
+	for f in u7s-control-plane u7s-worker; do \
+		$(KUBECTL) --namespace=$(U7S_NAMESPACE) rollout status --timeout=5m statefulset/$$f; \
+	done
+
+.PHONY: down
+down:
+	$(MAKE) --silent render | $(KUBECTL) delete --ignore-not-found -f -
+
+.PHONY: shell
+shell:
+	$(NODE_EXEC) -it $(CONTROL_PLANE_POD) -- bash
+
+.PHONY: logs
+logs:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- journalctl --follow --since="1 day ago"
+
+.PHONY: kubeconfig
+kubeconfig:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- sed -e "s/$(CONTROL_PLANE_NODE_NAME):6443/127.0.0.1:$(U7S_KUBE_APISERVER_LOCAL_PORT)/g" /etc/kubernetes/admin.conf >kubeconfig
+	@echo "# Run the following commands by yourself:"
+	@echo "make port-forward   # Run in a separate terminal"
+	@echo "export KUBECONFIG=$(shell pwd)/kubeconfig"
+
+.PHONY: port-forward
+port-forward:
+	$(KUBECTL) --namespace=$(U7S_NAMESPACE) port-forward pod/$(CONTROL_PLANE_POD) $(U7S_KUBE_APISERVER_LOCAL_PORT):6443
+
+.PHONY: kubeadm-init
+kubeadm-init:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- sh -euc "envsubst </usernetes/kubeadm-config.yaml >/tmp/kubeadm-config.yaml"
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- kubeadm init --config /tmp/kubeadm-config.yaml --skip-token-print
+	$(MAKE) patch-kube-proxy
+	$(MAKE) sync-external-ip
+	@echo "# Run 'make kubeadm-join' to join the worker pods"
+
+# The kube-proxy DaemonSet created by kubeadm runs with privileged: true,
+# which cannot be fulfilled inside a userns node pod: the sandbox of a
+# privileged pod with hostNetwork gets a fresh read-write sysfs mount, and
+# mounting sysfs requires the network namespace to be owned by the user
+# namespace, while the network namespace of the node pod is created by the
+# CRI of the outer cluster (i.e., owned by the initial user namespace).
+# So, drop privileged and grant just the capabilities needed for iptables.
+# The conntrack sysctls are already skipped via ../kubeadm-config.yaml .
+.PHONY: patch-kube-proxy
+patch-kube-proxy:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- kubectl --namespace=kube-system patch daemonset kube-proxy --patch '{"spec":{"template":{"spec":{"containers":[{"name":"kube-proxy","securityContext":{"privileged":false,"capabilities":{"add":["NET_ADMIN","NET_RAW"]}}}]}}}}'
+
+.PHONY: sync-external-ip
+sync-external-ip:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- /usernetes/Makefile.d/sync-external-ip.sh
+
+.PHONY: kubeadm-join
+kubeadm-join:
+	@set -eu; \
+	join_command="$$($(NODE_EXEC) $(CONTROL_PLANE_POD) -- kubeadm token create --print-join-command | tr -d '\r')"; \
+	for pod in $$($(KUBECTL) get pods --namespace=$(U7S_NAMESPACE) -l app.kubernetes.io/component=worker -o name); do \
+		echo "Joining $${pod}"; \
+		$(NODE_EXEC) "$${pod}" -- sh -euc "if [ -e /etc/kubernetes/kubelet.conf ]; then echo 'Already joined, skipping'; else $${join_command}; fi"; \
+	done
+	$(MAKE) sync-external-ip
+
+.PHONY: kubeadm-reset
+kubeadm-reset:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- kubeadm reset --force
+
+.PHONY: install-flannel
+install-flannel:
+	$(NODE_EXEC) $(CONTROL_PLANE_POD) -- /usernetes/Makefile.d/install-flannel.sh

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,273 @@
+# Kubernetes-in-Kubernetes (experimental)
+
+Usernetes can be deployed inside an existing Kubernetes cluster,
+as [UserNS-enabled pods](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/)
+(`hostUsers: false`), so as to mitigate potential container-breakout
+vulnerabilities of the inner cluster.
+
+This is the "Kubernetes-in-Kubernetes" analog of running Usernetes inside
+Rootless Docker: the node pods run in their own user namespaces, so "root"
+inside a node pod does not correspond to the root on the host.
+The node pods do **not** use `privileged: true`.
+Instead, they are granted all the *namespaced* capabilities, an unmasked
+procfs, and unconfined seccomp/AppArmor profiles, which do not provide the
+real root privileges on the hosts.
+
+> [!WARNING]
+>
+> This mode is experimental.
+
+## Requirements
+
+Requirements for the "outer" (host) Kubernetes cluster:
+
+- Kubernetes v1.33 or later is recommended.
+  The [`UserNamespacesSupport`](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/)
+  feature gate is enabled by default since v1.33 (GA in v1.36).
+  On v1.30 - v1.32, the feature gate has to be enabled manually.
+  The [`ProcMountType`](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+  feature gate is also required for `procMount: Unmasked`.
+- Node kernel >= 6.3: the kubelet mounts the volumes of a UserNS-enabled pod
+  with [idmapped mounts](https://lwn.net/Articles/896255/), and tmpfs (which
+  backs the `emptyDir` volumes with `medium: Memory`, plus `secret`,
+  `configMap`, `projected`, and `downwardAPI` volumes) only gained idmapped
+  mounts support in Linux 6.3. The filesystem backing the kubelet directory
+  (`/var/lib/kubelet`) has to support idmapped mounts as well.
+- CRI: containerd >= 2.1, or CRI-O >= 1.25.
+- OCI: runc >= 1.2, or crun >= 1.9.
+- The CRI has to mount `/sys/fs/cgroup` of the node pods **read-write**, so
+  that systemd inside them can manage its own (namespaced) cgroups; the OCI
+  runtime then chowns the cgroup to the mapped root of the user namespace.
+  This is *not* the default behavior for unprivileged pods:
+  - containerd: define a dedicated runtime handler with
+    [`cgroup_writable = true`](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
+    (containerd >= 2.1), restart containerd, and expose the handler to the
+    pods as a RuntimeClass:
+    ```toml
+    # /etc/containerd/config.toml (version = 3)
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.usernetes]
+      runtime_type = "io.containerd.runc.v2"
+      cgroup_writable = true
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.usernetes.options]
+        SystemdCgroup = true
+    ```
+    ```yaml
+    apiVersion: node.k8s.io/v1
+    kind: RuntimeClass
+    metadata:
+      name: usernetes
+    handler: usernetes
+    ```
+    Then set `U7S_RUNTIME_CLASS_NAME=usernetes` so that the node pods use the
+    RuntimeClass. Setting `cgroup_writable = true` on the default "runc"
+    handler works too, but is not recommended, as it would affect all the
+    unprivileged pods on the nodes.
+    For k3s, see
+    [`../.github/workflows/reusable-k8s-in-k8s.yaml`](../.github/workflows/reusable-k8s-in-k8s.yaml).
+  - CRI-O: allow the `cgroup2-mount-hierarchy-rw.crio.io` annotation
+    (already set in [`./usernetes.yaml`](./usernetes.yaml)) via
+    [`allowed_annotations`](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md)
+    in the runtime config, preferably on a dedicated runtime handler as well
+    (untested).
+- The `vxlan` and `br_netfilter` kernel modules loaded on the nodes
+  (see [`../init-host`](../init-host)).
+- `net.ipv4.conf.default.rp_filter` should be 0 (disabled) or 2 (loose) on the
+  nodes; the entrypoint of the node pods also tries to relax it by itself.
+- The Pod Security admission of the namespace must allow the `privileged`
+  profile, as the node pods opt out of several restrictions of the `baseline`
+  profile (capabilities, procMount, seccomp/AppArmor).
+  The pods are still isolated by user namespaces.
+
+Requirements for the client:
+
+- `kubectl` configured for the outer cluster
+- `envsubst` (GNU gettext)
+- GNU make
+
+## Usage
+
+The node image defaults to `ghcr.io/rootless-containers/usernetes:master`,
+which is built from the top-level [`Dockerfile`](../Dockerfile) and pushed to
+GHCR by the CI ([`../.github/workflows/image.yaml`](../.github/workflows/image.yaml))
+on every push to the master branch.
+The image can be built and pushed manually too, to a registry that is
+accessible from the outer cluster:
+
+```bash
+cd ..
+docker build -t <REGISTRY>/usernetes:latest .
+docker push <REGISTRY>/usernetes:latest
+cd kubernetes
+export U7S_IMAGE=<REGISTRY>/usernetes:latest
+```
+
+Bootstrap a cluster (see `make help`):
+
+```bash
+# Bootstrap a cluster with 1 control plane pod and ${U7S_WORKER_REPLICAS} (default: 1) worker pods
+make up
+make kubeadm-init
+make install-flannel
+make kubeadm-join
+
+# Enable kubectl
+make kubeconfig
+make port-forward   # Run in a separate terminal
+export KUBECONFIG=$(pwd)/kubeconfig
+kubectl get pods -A
+
+# Debug
+make logs
+make shell
+make down
+```
+
+The following environment variables are recognized:
+
+Name                            | Type    | Default value
+--------------------------------|---------|-----------------------------------------------
+`U7S_IMAGE`                     | String  | "ghcr.io/rootless-containers/usernetes:master"
+`U7S_NAMESPACE`                 | String  | "usernetes"
+`U7S_RUNTIME_CLASS_NAME`        | String  | "" (the default runtime handler of the outer cluster; see the requirements above)
+`U7S_WORKER_REPLICAS`           | Integer | 1
+`U7S_POD_SUBNET`                | String  | "10.200.0.0/16" (must not overlap with the subnets of the outer cluster)
+`U7S_SERVICE_SUBNET`            | String  | "10.201.0.0/16" (must not overlap with the subnets of the outer cluster)
+`U7S_KUBE_APISERVER_LOCAL_PORT` | Integer | 6443 (set to another port when 127.0.0.1:6443 is already taken, e.g., by the outer cluster)
+
+## How it works
+
+- The node pods are created as two StatefulSets (`u7s-control-plane` and
+  `u7s-worker`) with `hostUsers: false`, plus a headless Service `u7s` that
+  provides stable DNS names for the pods
+  (`<pod>.u7s.<namespace>.svc.cluster.local`).
+- `HOST_IP` and `NODE_IP` are set to the IP address of the pod itself, as the
+  pods can reach each other directly; no port needs to be published to the
+  hosts. Flannel of the inner cluster runs VXLAN on top of the pod network of
+  the outer cluster.
+- The pod and service subnets of the inner cluster default to 10.200.0.0/16
+  and 10.201.0.0/16, unlike in the Docker Compose mode (10.244.0.0/16 and
+  10.96.0.0/16): the subnets of the inner cluster must not overlap with the
+  subnets of the outer cluster, or the routes installed by Flannel of the
+  inner cluster would shadow the node pods of the outer cluster.
+- `make kubeadm-init` patches the kube-proxy DaemonSet of the inner cluster
+  to drop `privileged: true` (in favor of `NET_ADMIN` and `NET_RAW`):
+  a privileged pod with `hostNetwork` cannot be created inside a userns node
+  pod, as mounting a fresh sysfs requires the network namespace to be owned
+  by the user namespace, while the network namespace of the node pod is
+  created by the CRI of the outer cluster.
+- Unlike Docker named volumes, Kubernetes `emptyDir` volumes are not
+  initialized with the image content, so an init container populates the
+  `/etc`, `/opt`, and `/var` volumes before they are mounted over the image
+  content.
+- The image contains a copy of the Usernetes source tree in `/usernetes`
+  (bind-mounted from the host in the Docker Compose mode).
+
+## Multi-tenancy
+
+Multiple inner clusters can be created in the same outer cluster by using
+different namespaces:
+
+```bash
+export U7S_NAMESPACE=usernetes2
+# Change the port (default: 6443) for each of the tenants
+export U7S_KUBE_APISERVER_LOCAL_PORT=26443
+
+make up
+make kubeadm-init
+make install-flannel
+make kubeadm-join
+```
+
+- The node pods of different tenants never share UID ranges, even on the same
+  node: the kubelet allocates a distinct range of 65536 UIDs/GIDs to every
+  UserNS-enabled pod (`/etc/subuid` of the hosts is not involved).
+- The pod and service subnets (`U7S_POD_SUBNET` and `U7S_SERVICE_SUBNET`) do
+  not need to differ across the tenants: these subnets exist only inside the
+  network namespaces of the node pods. They just must not overlap with the
+  subnets of the outer cluster.
+- The RuntimeClass (`U7S_RUNTIME_CLASS_NAME`) is cluster-scoped and is shared
+  by the tenants.
+
+## Limitations
+
+- The state of the inner cluster is stored on `emptyDir` volumes and does not
+  survive the recreation of the node pods. Persistent volumes
+  (`volumeClaimTemplates`) are deliberately not used yet: the IP addresses of
+  the pods change across restarts, which invalidates the certificates and the
+  etcd configuration of the inner cluster anyway, so persisting the state
+  would just prevent the recreated pods from starting cleanly. Recreate the
+  cluster (`make down up kubeadm-init ...`) after the node pods are recreated.
+  Switching to PVCs may be revisited in the future, along with regenerating
+  the IP-dependent state on boot.
+- Node ports of the inner cluster are not exposed automatically.
+  `kubectl port-forward` to the node pods can be used instead.
+- Most of the limitations of the Docker Compose mode
+  (see the top-level [`README.md`](../README.md)) apply to this mode too.
+- The `/lib/modules` and `/boot` directories of the hosts are mounted into the
+  node pods with read-only `hostPath` volumes, just for checking the presence
+  of the kernel modules and for reading the kernel config in the preflight
+  checks of kubeadm. The volumes can be removed from
+  [`usernetes.yaml`](./usernetes.yaml) if `hostPath` volumes are prohibited in
+  the outer cluster (`kubeadm-init` and `kubeadm-join` would then need
+  `--ignore-preflight-errors=SystemVerification`).
+
+## Testing with k3s
+
+The CI (see [`../.github/workflows/reusable-k8s-in-k8s.yaml`](../.github/workflows/reusable-k8s-in-k8s.yaml))
+smoke-tests this mode with [k3s](https://k3s.io/) as the outer cluster,
+with a dedicated "usernetes" runtime handler (`cgroup_writable = true`)
+defined in the containerd of k3s and exposed as the "usernetes" RuntimeClass.
+The same steps can be used locally, on a host that satisfies the kernel
+requirements above. Note that k3s occupies 127.0.0.1:6443 for the API server
+of the outer cluster, so the API server of the inner cluster has to be
+forwarded to another local port:
+
+```bash
+docker build -t usernetes:ci ..
+docker save usernetes:ci | sudo k3s ctr images import -
+export U7S_IMAGE=usernetes:ci U7S_RUNTIME_CLASS_NAME=usernetes U7S_KUBE_APISERVER_LOCAL_PORT=16443
+make up
+make kubeadm-init
+make install-flannel
+make kubeadm-join
+```
+
+## Testing with Lima (multi-node)
+
+[`../hack/create-outer-cluster-lima.sh`](../hack/create-outer-cluster-lima.sh)
+creates a two-node outer cluster with [Lima](https://lima-vm.io/)'s
+`template:k8s`, with the "usernetes" runtime handler and RuntimeClass
+configured. The node pods are then spread across the outer nodes
+(see `topologySpreadConstraints` in [`./usernetes.yaml`](./usernetes.yaml)),
+so the inner Flannel runs VXLAN across the outer nodes.
+The CI also tests this mode; see
+[`../.github/workflows/reusable-k8s-in-k8s.yaml`](../.github/workflows/reusable-k8s-in-k8s.yaml).
+
+```bash
+./hack/create-outer-cluster-lima.sh
+export KUBECONFIG=$HOME/.lima/host0/copied-from-guest/kubeconfig.yaml
+export U7S_IMAGE=usernetes:ci U7S_RUNTIME_CLASS_NAME=usernetes U7S_KUBE_APISERVER_LOCAL_PORT=16443
+```
+
+## Troubleshooting
+
+- Pod fails with `user namespaces are not supported`:
+  make sure that the feature gate, the CRI, the OCI runtime, and the kernel
+  of the outer cluster satisfy the requirements above.
+- Node pod keeps restarting, with
+  `Failed to create /init.scope control group: Read-only file system`
+  in `kubectl logs` (the message may only appear with `tty: true`):
+  `/sys/fs/cgroup` is mounted read-only in the pod, and systemd cannot manage
+  its cgroups. Configure the CRI to mount the cgroups read-write
+  (`cgroup_writable = true` for containerd, on a dedicated runtime handler
+  selected via `U7S_RUNTIME_CLASS_NAME`; see the requirements above).
+- Pod is rejected due to `procMount`:
+  make sure that the `ProcMountType` feature gate is enabled.
+- Pod is rejected by the Pod Security admission:
+  make sure that the namespace allows the `privileged` profile. The manifest
+  labels the namespace with `pod-security.kubernetes.io/enforce=privileged`,
+  but an external policy controller may still reject the pods.
+- Flannel of the inner cluster fails to establish the VXLAN network:
+  make sure that the `vxlan` kernel module is loaded on the hosts, and that
+  the network policy of the outer cluster allows UDP port 8472 between the
+  node pods.

--- a/kubernetes/usernetes.yaml
+++ b/kubernetes/usernetes.yaml
@@ -1,0 +1,401 @@
+# Usernetes inside Kubernetes, as UserNS-enabled pods (hostUsers: false).
+#
+# Use `make render` / `make up`, not `kubectl apply -f`,
+# as this YAML requires ${...} variables to be set.
+#
+# The node pods do NOT run with `privileged: true`.
+# Instead, they run inside their own user namespaces with all the capabilities,
+# an unmasked procfs, and unconfined seccomp/AppArmor profiles.
+# "Root" in a node pod is not the root on the host: this is analogous to
+# running Usernetes inside Rootless Docker.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${U7S_NAMESPACE}
+  labels:
+    # The node pods opt out of the restrictions of the "baseline" profile
+    # (capabilities, procMount, seccomp/AppArmor), although they are still
+    # isolated by user namespaces.
+    pod-security.kubernetes.io/enforce: privileged
+---
+# Headless service that provides stable DNS names for the node pods:
+# <pod>.u7s.<namespace>.svc.cluster.local
+apiVersion: v1
+kind: Service
+metadata:
+  name: u7s
+  namespace: ${U7S_NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: usernetes
+spec:
+  clusterIP: None
+  # Keep resolving the DNS names of the node pods even while they are not
+  # Ready yet (readiness is gated on containerd; see the StatefulSets below),
+  # as the node names of the inner cluster must stay resolvable.
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/part-of: usernetes
+  ports:
+    - name: kube-apiserver
+      port: 6443
+      protocol: TCP
+    - name: etcd
+      port: 2379
+      protocol: TCP
+    - name: kubelet
+      port: 10250
+      protocol: TCP
+    - name: flannel
+      port: 8472
+      protocol: UDP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: u7s-control-plane
+  namespace: ${U7S_NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: usernetes
+    app.kubernetes.io/component: control-plane
+spec:
+  serviceName: u7s
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: usernetes
+      app.kubernetes.io/component: control-plane
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: usernetes
+        app.kubernetes.io/component: control-plane
+      annotations:
+        # For CRI-O: mount /sys/fs/cgroup read-write, so that systemd inside
+        # the node pod can manage its own (namespaced) cgroups.
+        # The annotation has to be listed in `allowed_annotations` of the
+        # CRI-O runtime config; ignored otherwise, and by containerd
+        # (containerd needs `cgroup_writable = true` instead; see ./README.md).
+        # The second one is the deprecated name for older CRI-O releases.
+        cgroup2-mount-hierarchy-rw.crio.io: "true"
+        io.kubernetes.cri-o.cgroup2-mount-hierarchy-rw: "true"
+    spec:
+      # Run the node in a user namespace (KEP-127).
+      hostUsers: false
+      # The RuntimeClass is expected to be backed by a runtime handler with
+      # `cgroup_writable = true` (containerd >= 2.1); see ./README.md.
+      # Renders as null (i.e., the default runtime handler) when
+      # U7S_RUNTIME_CLASS_NAME is empty.
+      runtimeClassName: ${U7S_RUNTIME_CLASS_NAME}
+      # Prefer spreading the node pods across the nodes of the outer
+      # cluster, so that the inner cluster can remain available when a
+      # single outer node goes down. The inner Flannel then runs VXLAN
+      # across the outer nodes.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: usernetes
+      # The inner cluster must not inherit credentials of the outer cluster.
+      automountServiceAccountToken: false
+      initContainers:
+        # Kubernetes emptyDir volumes are created empty, unlike Docker named
+        # volumes that are initialized with the image content on the first
+        # use. So, /etc, /opt, and /var have to be populated manually before
+        # mounting the volumes over them.
+        - name: populate-volumes
+          image: ${U7S_IMAGE}
+          command:
+            - /bin/sh
+            - -euc
+            - |
+              for d in etc opt var; do
+                if [ ! -f "/u7s-vol/${d}/.u7s-populated" ]; then
+                  cp -a "/${d}/." "/u7s-vol/${d}/"
+                  touch "/u7s-vol/${d}/.u7s-populated"
+                fi
+              done
+          volumeMounts:
+            - name: node-etc
+              mountPath: /u7s-vol/etc
+            - name: node-opt
+              mountPath: /u7s-vol/opt
+            - name: node-var
+              mountPath: /u7s-vol/var
+      containers:
+        - name: node
+          image: ${U7S_IMAGE}
+          workingDir: /usernetes
+          env:
+            - name: U7S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: U7S_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # HOST_IP is the IP address that is accessible from the other
+            # node pods. Unlike in the Docker Compose mode, this is just the
+            # IP address of the pod itself.
+            - name: HOST_IP
+              value: "$(U7S_POD_IP)"
+            - name: NODE_IP
+              value: "$(U7S_POD_IP)"
+            # NODE_NAME must be resolvable from the other node pods.
+            # "<pod>.u7s" resolves via the headless service "u7s".
+            - name: NODE_NAME
+              value: "$(U7S_POD_NAME).u7s"
+            - name: PORT_ETCD
+              value: "2379"
+            - name: PORT_KUBELET
+              value: "10250"
+            - name: PORT_FLANNEL
+              value: "8472"
+            - name: PORT_KUBE_APISERVER
+              value: "6443"
+            # The subnets of the inner cluster; must not overlap with the
+            # subnets of the outer cluster (see ../kubeadm-config.yaml and
+            # ../Makefile.d/install-flannel.sh).
+            - name: POD_SUBNET
+              value: "${U7S_POD_SUBNET}"
+            - name: SERVICE_SUBNET
+              value: "${U7S_SERVICE_SUBNET}"
+            - name: KUBECONFIG
+              value: /etc/kubernetes/admin.conf
+          ports:
+            - name: kube-apiserver
+              containerPort: 6443
+              protocol: TCP
+            - name: etcd
+              containerPort: 2379
+              protocol: TCP
+            - name: kubelet
+              containerPort: 10250
+              protocol: TCP
+            - name: flannel
+              containerPort: 8472
+              protocol: UDP
+          # systemd starts containerd asynchronously after the entrypoint, so
+          # gate readiness on the CRI socket: `make up` (kubectl rollout
+          # status) then blocks until `kubeadm init` can talk to containerd.
+          readinessProbe:
+            exec:
+              command:
+                - test
+                - -S
+                - /run/containerd/containerd.sock
+            periodSeconds: 5
+          securityContext:
+            # All these settings are safe because the pod runs in a user
+            # namespace (hostUsers: false); the capabilities are "namespaced"
+            # and do not correspond to the real capabilities on the host.
+            capabilities:
+              add:
+                - ALL
+            # Unmasked procMount requires `hostUsers: false` and the
+            # `ProcMountType` feature gate.
+            procMount: Unmasked
+            seccompProfile:
+              type: Unconfined
+            appArmorProfile:
+              type: Unconfined
+          volumeMounts:
+            - name: node-etc
+              mountPath: /etc
+            - name: node-opt
+              mountPath: /opt
+            - name: node-var
+              mountPath: /var
+            - name: run
+              mountPath: /run
+            - name: tmp
+              mountPath: /tmp
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+      volumes:
+        - name: node-etc
+          emptyDir: {}
+        - name: node-opt
+          emptyDir: {}
+        - name: node-var
+          emptyDir: {}
+        - name: run
+          emptyDir:
+            medium: Memory
+        - name: tmp
+          emptyDir:
+            medium: Memory
+        # /lib/modules and /boot of the host running the outer Kubernetes,
+        # as in the Docker Compose mode (../docker-compose.yaml).
+        # /lib/modules is used for checking the presence of the kernel
+        # modules; /boot for the kernel config (kubeadm preflight).
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: boot
+          hostPath:
+            path: /boot
+            type: Directory
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: u7s-worker
+  namespace: ${U7S_NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: usernetes
+    app.kubernetes.io/component: worker
+spec:
+  serviceName: u7s
+  replicas: ${U7S_WORKER_REPLICAS}
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: usernetes
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: usernetes
+        app.kubernetes.io/component: worker
+      annotations:
+        # See the comment in the control plane StatefulSet above.
+        cgroup2-mount-hierarchy-rw.crio.io: "true"
+        io.kubernetes.cri-o.cgroup2-mount-hierarchy-rw: "true"
+    spec:
+      hostUsers: false
+      # See the comments in the control plane StatefulSet above.
+      runtimeClassName: ${U7S_RUNTIME_CLASS_NAME}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: usernetes
+      automountServiceAccountToken: false
+      initContainers:
+        - name: populate-volumes
+          image: ${U7S_IMAGE}
+          command:
+            - /bin/sh
+            - -euc
+            - |
+              for d in etc opt var; do
+                if [ ! -f "/u7s-vol/${d}/.u7s-populated" ]; then
+                  cp -a "/${d}/." "/u7s-vol/${d}/"
+                  touch "/u7s-vol/${d}/.u7s-populated"
+                fi
+              done
+          volumeMounts:
+            - name: node-etc
+              mountPath: /u7s-vol/etc
+            - name: node-opt
+              mountPath: /u7s-vol/opt
+            - name: node-var
+              mountPath: /u7s-vol/var
+      containers:
+        - name: node
+          image: ${U7S_IMAGE}
+          workingDir: /usernetes
+          env:
+            - name: U7S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: U7S_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              value: "$(U7S_POD_IP)"
+            - name: NODE_IP
+              value: "$(U7S_POD_IP)"
+            - name: NODE_NAME
+              value: "$(U7S_POD_NAME).u7s"
+            - name: PORT_ETCD
+              value: "2379"
+            - name: PORT_KUBELET
+              value: "10250"
+            - name: PORT_FLANNEL
+              value: "8472"
+            - name: PORT_KUBE_APISERVER
+              value: "6443"
+            # The subnets of the inner cluster; must not overlap with the
+            # subnets of the outer cluster (see ../kubeadm-config.yaml and
+            # ../Makefile.d/install-flannel.sh).
+            - name: POD_SUBNET
+              value: "${U7S_POD_SUBNET}"
+            - name: SERVICE_SUBNET
+              value: "${U7S_SERVICE_SUBNET}"
+            - name: KUBECONFIG
+              value: /etc/kubernetes/admin.conf
+          ports:
+            - name: kubelet
+              containerPort: 10250
+              protocol: TCP
+            - name: flannel
+              containerPort: 8472
+              protocol: UDP
+          # See the comment in the control plane StatefulSet above.
+          readinessProbe:
+            exec:
+              command:
+                - test
+                - -S
+                - /run/containerd/containerd.sock
+            periodSeconds: 5
+          securityContext:
+            capabilities:
+              add:
+                - ALL
+            procMount: Unmasked
+            seccompProfile:
+              type: Unconfined
+            appArmorProfile:
+              type: Unconfined
+          volumeMounts:
+            - name: node-etc
+              mountPath: /etc
+            - name: node-opt
+              mountPath: /opt
+            - name: node-var
+              mountPath: /var
+            - name: run
+              mountPath: /run
+            - name: tmp
+              mountPath: /tmp
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: boot
+              mountPath: /boot
+              readOnly: true
+      volumes:
+        - name: node-etc
+          emptyDir: {}
+        - name: node-opt
+          emptyDir: {}
+        - name: node-var
+          emptyDir: {}
+        - name: run
+          emptyDir:
+            medium: Memory
+        - name: tmp
+          emptyDir:
+            medium: Memory
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: boot
+          hostPath:
+            path: /boot
+            type: Directory


### PR DESCRIPTION
Usernetes can now be deployed inside an existing Kubernetes cluster, as pods running in [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) (`hostUsers: false`, KEP-127).

This is the Kubernetes-in-Kubernetes analog of running Usernetes inside Rootless Docker: "root" in a node pod is not the root on the hosts, so as to mitigate potential container-breakout vulnerabilities of the inner cluster.

With this new mode, the project generation is bumped from Gen2 to Gen3. Gen3 is a superset of Gen2: the Kubernetes-in-Docker (Docker Compose) mode remains the default deployment mode.

## Usage

```bash
cd kubernetes
make up
make kubeadm-init
make install-flannel
make kubeadm-join

make kubeconfig
make port-forward   # Run in a separate terminal
export KUBECONFIG=$(pwd)/kubeconfig
kubectl get pods -A
```

See `kubernetes/README.md` for the requirements of the outer cluster (kernel >= 6.3, containerd >= 2.1 or CRI-O >= 1.25, etc.) and for the full documentation.

Fixes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
