### PR TITLE
kubernetes: allow creating privileged pods in the inner cluster

### DIFF
--- a/.github/workflows/reusable-k8s-in-k8s.yaml
+++ b/.github/workflows/reusable-k8s-in-k8s.yaml
@@ -38,6 +38,13 @@ jobs:
           sudo modprobe br_netfilter
           sudo modprobe vxlan
 
+      - name: Provide a read-write sysfs instance for the node pods
+        # Needed for creating privileged pods in the inner cluster;
+        # see ./README.md and the comments in ./usernetes.yaml.
+        run: |
+          sudo mkdir -p /run/usernetes/sysfs
+          sudo unshare --net mount -t sysfs -o nosuid,nodev,noexec sysfs /run/usernetes/sysfs
+
       - name: Create the outer Kubernetes cluster (k3s)
         run: |
           set -eux -o pipefail
@@ -121,6 +128,18 @@ jobs:
         run: |
           kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
           ./hack/test-smoke.sh
+
+      - name: Verify that a privileged pod can be created in the inner cluster
+        # https://github.com/rootless-containers/usernetes/issues/396
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          set -eux -o pipefail
+          kubectl run privileged-test --image=alpine --restart=Never \
+            --overrides='{"spec":{"containers":[{"name":"privileged-test","image":"alpine","command":["sh","-euxc","grep -w sysfs /proc/mounts"],"securityContext":{"privileged":true}}]}}'
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/privileged-test --timeout=2m
+          kubectl logs privileged-test
+          kubectl delete pod privileged-test
 
       # Multi-tenancy: multiple inner clusters can be created in the same
       # outer cluster by using different namespaces.
@@ -276,6 +295,18 @@ jobs:
         run: |
           kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
           ./hack/test-smoke.sh
+
+      - name: Verify that a privileged pod can be created in the inner cluster
+        # https://github.com/rootless-containers/usernetes/issues/396
+        env:
+          KUBECONFIG: "${{ github.workspace }}/kubernetes/kubeconfig"
+        run: |
+          set -eux -o pipefail
+          kubectl run privileged-test --image=alpine --restart=Never \
+            --overrides='{"spec":{"containers":[{"name":"privileged-test","image":"alpine","command":["sh","-euxc","grep -w sysfs /proc/mounts"],"securityContext":{"privileged":true}}]}}'
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/privileged-test --timeout=2m
+          kubectl logs privileged-test
+          kubectl delete pod privileged-test
 
       - if: failure()
         name: "Debug (outer cluster)"

--- a/hack/create-outer-cluster-lima.sh
+++ b/hack/create-outer-cluster-lima.sh
@@ -31,8 +31,16 @@ ${LIMACTL} start --network lima:user-v2 --name=host1 ${LIMACTL_CREATE_ARGS} \
 # the node pods can manage its own (namespaced) cgroups.
 # /etc/containerd/conf.d/*.toml is imported by the containerd config of
 # template:k8s.
+#
+# Also provide a read-write sysfs instance at /run/usernetes/sysfs, to be
+# mounted into the node pods; needed for creating privileged pods in the
+# inner cluster (see ../kubernetes/README.md).
+# `unshare --net` detaches the instance from the netns of the host, so it
+# does not expose the network devices of the host.
 for host in host0 host1; do
-	${LIMACTL} shell "${host}" sudo sh -euxc 'cat >/etc/containerd/conf.d/usernetes.toml <<EOF
+	${LIMACTL} shell "${host}" sudo sh -euxc 'mkdir -p /run/usernetes/sysfs
+mountpoint -q /run/usernetes/sysfs || unshare --net mount -t sysfs -o nosuid,nodev,noexec sysfs /run/usernetes/sysfs
+cat >/etc/containerd/conf.d/usernetes.toml <<EOF
 version = 2
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -71,6 +71,25 @@ Requirements for the "outer" (host) Kubernetes cluster:
     (untested).
 - The `vxlan` and `br_netfilter` kernel modules loaded on the nodes
   (see [`../init-host`](../init-host)).
+- (Optional) To create privileged pods in the inner cluster, the nodes have
+  to provide an extra read-write sysfs instance at `/run/usernetes/sysfs`:
+  ```bash
+  sudo mkdir -p /run/usernetes/sysfs
+  sudo unshare --net mount -t sysfs -o nosuid,nodev,noexec sysfs /run/usernetes/sysfs
+  ```
+  The kernel allows mounting a fresh read-write sysfs (as needed by runc for
+  a privileged pod of the inner cluster) in a mount namespace owned by a
+  user namespace only when the mount namespace already contains a
+  fully-visible read-write sysfs instance, while the `/sys` of the node pods
+  is mounted read-only by the CRI of the outer cluster. The instance is
+  provided by the host (mounted into the node pods via a `hostPath` volume;
+  see [`./usernetes.yaml`](./usernetes.yaml)), as the node pods cannot mount
+  it by themselves. `unshare --net` detaches the instance from the network
+  namespace of the host, so it does not expose the network devices of the
+  host; sysfs cannot be written by the node pods anyway, as the files are
+  owned by the "real" root. Without this mount, everything else still works;
+  only the creation of privileged pods in the inner cluster fails
+  (see [issue #396](https://github.com/rootless-containers/usernetes/issues/396)).
 - `net.ipv4.conf.default.rp_filter` should be 0 (disabled) or 2 (loose) on the
   nodes; the entrypoint of the node pods also tries to relax it by itself.
 - The Pod Security admission of the namespace must allow the `privileged`
@@ -201,6 +220,14 @@ make kubeadm-join
   the IP-dependent state on boot.
 - Node ports of the inner cluster are not exposed automatically.
   `kubectl port-forward` to the node pods can be used instead.
+- Privileged pods of the inner cluster need the extra sysfs instance on the
+  hosts (see the requirements above). Privileged pods with `hostNetwork`
+  get a read-only `/sys` (a bind mount of the `/sys` of the node pod,
+  created by runc in place of a fresh read-write sysfs): mounting a fresh
+  sysfs requires the network namespace to be owned by the user namespace,
+  while the network namespace of the node pod is created by the CRI of the
+  outer cluster (see also the comment on `patch-kube-proxy` in
+  [`./Makefile`](./Makefile)).
 - Most of the limitations of the Docker Compose mode
   (see the top-level [`README.md`](../README.md)) apply to this mode too.
 - The `/lib/modules` and `/boot` directories of the hosts are mounted into the
@@ -271,3 +298,9 @@ export U7S_IMAGE=usernetes:ci U7S_RUNTIME_CLASS_NAME=usernetes U7S_KUBE_APISERVE
   make sure that the `vxlan` kernel module is loaded on the hosts, and that
   the network policy of the outer cluster allows UDP port 8472 between the
   node pods.
+- A privileged pod of the inner cluster fails with
+  `error mounting "sysfs" to rootfs at "/sys": ... operation not permitted`:
+  make sure that the hosts provide the read-write sysfs instance at
+  `/run/usernetes/sysfs` (see the requirements above), and recreate the node
+  pods if the instance was mounted after them. For the `/sys` of privileged
+  pods with `hostNetwork`, see the limitations above.

--- a/kubernetes/usernetes.yaml
+++ b/kubernetes/usernetes.yaml
@@ -219,6 +219,10 @@ spec:
             - name: boot
               mountPath: /boot
               readOnly: true
+            # Must not be readOnly: the sysfs submount has to remain
+            # read-write (see the comment on the volume below).
+            - name: sysfs-rw
+              mountPath: /mnt/usernetes
       volumes:
         - name: node-etc
           emptyDir: {}
@@ -244,6 +248,24 @@ spec:
           hostPath:
             path: /boot
             type: Directory
+        # An extra read-write sysfs instance provided by the host, mounted
+        # at /run/usernetes/sysfs on the host (see ./README.md). Needed only
+        # for creating privileged pods in the inner cluster: runc inside the
+        # node pod may mount a fresh read-write sysfs for such pods only
+        # when the mount namespace already contains a fully-visible
+        # read-write sysfs instance, and the /sys of the node pod itself is
+        # read-only (issue #396).
+        # The parent directory is mounted instead of the sysfs itself, as
+        # sysfs does not support the idmapped mounts that the kubelet uses
+        # for the volumes of UserNS-enabled pods; the sysfs instance comes
+        # along as a submount of the bind mount.
+        # With DirectoryOrCreate, the node pods still run on hosts that do
+        # not provide the sysfs instance; only the creation of privileged
+        # pods in the inner cluster fails then.
+        - name: sysfs-rw
+          hostPath:
+            path: /run/usernetes
+            type: DirectoryOrCreate
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -378,6 +400,9 @@ spec:
             - name: boot
               mountPath: /boot
               readOnly: true
+            # See the comments in the control plane StatefulSet above.
+            - name: sysfs-rw
+              mountPath: /mnt/usernetes
       volumes:
         - name: node-etc
           emptyDir: {}
@@ -399,3 +424,7 @@ spec:
           hostPath:
             path: /boot
             type: Directory
+        - name: sysfs-rw
+          hostPath:
+            path: /run/usernetes
+            type: DirectoryOrCreate


### PR DESCRIPTION
For a privileged pod, runc has to mount a fresh read-write sysfs, which the kernel allows in a mount namespace owned by a user namespace only when the mount namespace already contains a fully-visible read-write sysfs instance. The /sys of the node pods is mounted read-only by the CRI of the outer cluster, and the node pods cannot mount a read-write instance by themselves, so it has to be provided by the host, at /run/usernetes/sysfs, and mounted into the node pods via a hostPath volume. The parent directory is mounted instead of the sysfs itself, as sysfs does not support the idmapped mounts that the kubelet uses for the volumes of UserNS-enabled pods.

This issue does not occur in the Docker Compose mode: there the node container runs with `privileged: true` (which is safe under Rootless Docker, as it only grants the capabilities that are namespaced in the RootlessKit user namespace), so Docker mounts its /sys read-write, which already satisfies the visibility requirement. A UserNS-enabled Kubernetes pod cannot be privileged, and the CRI has no option for mounting /sys of an unprivileged pod read-write (unlike `cgroup_writable` for cgroups).

Privileged pods with hostNetwork can be created even without this fix, although their /sys is a read-only bind mount of the /sys of the node pod, as mounting a fresh sysfs requires the network namespace to be owned by the user namespace. The network namespace of a node pod is created by the CRI of the outer cluster, i.e., owned by the initial user namespace; this also cannot happen in the Docker Compose mode, where the network namespace is created inside the RootlessKit user namespace.

Fix #396