### PR TITLE
udev: rename SLIRP4NETNS to FLANNEL_IGNORE_IP_CHECKSUM

### DIFF
--- a/Dockerfile.d/etc_udev_rules.d_90-flannel.rules
+++ b/Dockerfile.d/etc_udev_rules.d_90-flannel.rules
@@ -4,4 +4,4 @@
 # https://github.com/karmab/kcli/commit/b1a8eff658d17cf4e28162f0fa2c8b2b10e5ad00
 
 # Apparently only needed when the container engine is using slirp4netns as the rootless network driver
-SUBSYSTEM=="net", ACTION=="add|change|move", ENV{INTERFACE}=="flannel.1", RUN+="/bin/sh -c '! test -e /run/u7s-slirp4netns || /usr/sbin/ethtool -K flannel.1 tx-checksum-ip-generic off'"
+SUBSYSTEM=="net", ACTION=="add|change|move", ENV{INTERFACE}=="flannel.1", RUN+="/bin/sh -c '! test -e /run/u7s-flannel-ignore-ip-checksum || /usr/sbin/ethtool -K flannel.1 tx-checksum-ip-generic off'"

--- a/Dockerfile.d/u7s-entrypoint.sh
+++ b/Dockerfile.d/u7s-entrypoint.sh
@@ -22,11 +22,11 @@ for f in /proc/sys/net/ipv4/conf/default/rp_filter /proc/sys/net/ipv4/conf/all/r
 	fi
 done
 
-# Propagate SLIRP4NETNS to the udev rule, as udev RUN programs cannot see the
-# environment variables of the container.
-case "${SLIRP4NETNS:-}" in
+# Propagate FLANNEL_IGNORE_IP_CHECKSUM to the udev rule, as udev RUN programs
+# cannot see the environment variables of the container.
+case "${FLANNEL_IGNORE_IP_CHECKSUM:-}" in
 "1" | "true")
-	touch /run/u7s-slirp4netns
+	touch /run/u7s-flannel-ignore-ip-checksum
 	;;
 esac
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ export CONTAINER_ENGINE_TYPE ?= $(shell $(CURDIR)/Makefile.d/detect-container-en
 
 COMPOSE ?= $(shell $(CURDIR)/Makefile.d/detect-container-engine.sh COMPOSE)
 
-export SLIRP4NETNS ?= $(shell $(CURDIR)/Makefile.d/detect-container-engine.sh SLIRP4NETNS)
+export FLANNEL_IGNORE_IP_CHECKSUM ?= $(shell $(CURDIR)/Makefile.d/detect-container-engine.sh FLANNEL_IGNORE_IP_CHECKSUM)
 
 NODE_SERVICE_NAME := node
 NODE_SHELL := $(COMPOSE) exec \

--- a/Makefile.d/detect-container-engine.sh
+++ b/Makefile.d/detect-container-engine.sh
@@ -30,24 +30,24 @@ if [ -z "${COMPOSE}" ]; then
 	fi
 fi
 
-# SLIRP4NETNS is set to 1 when the container engine provides the network with slirp4netns.
+# FLANNEL_IGNORE_IP_CHECKSUM is set to 1 when the container engine provides the network with slirp4netns.
 # slirp4netns silently drops VXLAN packets with an unfilled UDP checksum,
 # so the flannel.1 udev rule (Dockerfile.d/etc_udev_rules.d_90-flannel.rules)
 # has to disable the checksum offloading.
 # The variable can also be set manually to override the detection.
-: "${SLIRP4NETNS:=}"
-if [ -z "${SLIRP4NETNS}" ]; then
+: "${FLANNEL_IGNORE_IP_CHECKSUM:=}"
+if [ -z "${FLANNEL_IGNORE_IP_CHECKSUM}" ]; then
 	case "${CONTAINER_ENGINE_TYPE}" in
 	"podman")
 		if [ "$(${CONTAINER_ENGINE} info --format '{{.Host.Security.Rootless}}/{{.Host.RootlessNetworkCmd}}' 2>/dev/null)" = "true/slirp4netns" ]; then
-			SLIRP4NETNS=1
+			FLANNEL_IGNORE_IP_CHECKSUM=1
 		fi
 		;;
 	"docker" | "nerdctl")
 		# The RootlessKit network driver is exposed as the "rootlesskit" server
 		# component (absent in the rootful mode).
 		if [ "$(${CONTAINER_ENGINE} version --format '{{range .Server.Components}}{{if eq .Name "rootlesskit"}}{{.Details.NetworkDriver}}{{end}}{{end}}' 2>/dev/null)" = "slirp4netns" ]; then
-			SLIRP4NETNS=1
+			FLANNEL_IGNORE_IP_CHECKSUM=1
 		fi
 		;;
 	esac
@@ -58,11 +58,11 @@ case "$#" in
 	echo "CONTAINER_ENGINE=${CONTAINER_ENGINE}"
 	echo "CONTAINER_ENGINE_TYPE=${CONTAINER_ENGINE_TYPE}"
 	echo "COMPOSE=${COMPOSE}"
-	echo "SLIRP4NETNS=${SLIRP4NETNS}"
+	echo "FLANNEL_IGNORE_IP_CHECKSUM=${FLANNEL_IGNORE_IP_CHECKSUM}"
 	;;
 1)
 	case "$1" in
-	"CONTAINER_ENGINE" | "CONTAINER_ENGINE_TYPE" | "COMPOSE" | "SLIRP4NETNS")
+	"CONTAINER_ENGINE" | "CONTAINER_ENGINE_TYPE" | "COMPOSE" | "FLANNEL_IGNORE_IP_CHECKSUM")
 		echo "${!1}"
 		;;
 	*)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,8 +37,9 @@ services:
       HOST_IP: ${HOST_IP}
       POD_SUBNET: ${POD_SUBNET}
       SERVICE_SUBNET: ${SERVICE_SUBNET}
-      # Set to 1 when the network is provided by slirp4netns
-      SLIRP4NETNS: ${SLIRP4NETNS:-}
+      # Set to 1 to disable the IP checksum offloading on flannel.1.
+      # Needed when the network is provided by slirp4netns.
+      FLANNEL_IGNORE_IP_CHECKSUM: ${FLANNEL_IGNORE_IP_CHECKSUM:-}
     sysctls:
       - net.ipv4.ip_forward=1
       # In addition, `net.ipv4.conf.default.rp_filter`


### PR DESCRIPTION
The variable controls whether to disable the IP checksum offloading on flannel.1, and is not inherently specific to slirp4netns (although it is automatically set to 1 when the container engine provides the network with slirp4netns). Users who set SLIRP4NETNS=1 manually have to switch to the new name.

The flag file for propagating the variable to the udev rule is renamed from /run/u7s-slirp4netns to /run/u7s-flannel-ignore-ip-checksum accordingly.

Follow-up to 
- #407